### PR TITLE
feat(website): migrate forum data layer to Hono API + Supabase auth env

### DIFF
--- a/website/.env.local.example
+++ b/website/.env.local.example
@@ -19,3 +19,6 @@ NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=your-publishable-key
 # Local dev: http://localhost:8787
 # Production: https://api.cccsolutions.ca
 NEXT_PUBLIC_API_URL=http://localhost:8787
+
+# Cloudflare Turnstile site key — public, used to render the widget on auth forms.
+NEXT_PUBLIC_TURNSTILE_SITE_KEY=your-turnstile-site-key

--- a/website/.env.production
+++ b/website/.env.production
@@ -1,0 +1,25 @@
+# =============================================================================
+# PUBLIC values — committing this file is NOT a security risk.
+#
+# Every var below is NEXT_PUBLIC_*, which Next.js bakes into the client bundle
+# at build time. They are shipped to every browser that loads the site, so
+# there is nothing here for a secret to leak: the Supabase publishable key is
+# designed to be public (Row Level Security is the real guard, and privileged
+# writes go through the Hono API, never straight to Supabase), the URLs are
+# just endpoints, and the Turnstile site key is meant to be embedded in pages.
+# None of these can perform a privileged action on their own.
+#
+# This file is read by `next build` for the production build (Cloudflare
+# Workers Builds via OpenNext). Do not put real secrets here — those belong
+# in the Worker's Secrets tab / CI environment instead.
+# =============================================================================
+
+NEXT_PUBLIC_SUPABASE_URL=https://ccjcesfbqlnosienatsz.supabase.co
+
+# TODO(william): fill in from Supabase dashboard -> Settings -> API -> publishable key
+# before deploying — left as a placeholder, this build will not have working auth
+# until it's set.
+NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=__FILL_IN_FROM_SUPABASE_DASHBOARD__
+
+NEXT_PUBLIC_API_URL=https://api.cccsolutions.ca
+NEXT_PUBLIC_TURNSTILE_SITE_KEY=0x4AAAAAAEJ4VEBIuWvd7MjT

--- a/website/app/create-post/page.tsx
+++ b/website/app/create-post/page.tsx
@@ -1,94 +1,70 @@
 'use client';
 
 import React, { useEffect, useRef, useState } from 'react';
-import PocketBase from 'pocketbase';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { ArrowLeftIcon } from '@radix-ui/react-icons';
 import { toast } from 'sonner';
-import { isPostCommitHookBug } from '../../lib/pocketbase-bug';
 import { Button } from '../../components/ui/button';
 import { SectionContainer } from '../../components/ui/section-container';
+import { supabase, apiFetch } from '../../lib/supabase';
+import type { Session } from '@supabase/supabase-js';
 import dynamic from 'next/dynamic';
 
 const ReactQuill = dynamic(() => import('react-quill-new'), { ssr: false });
 import 'react-quill-new/dist/quill.snow.css';
 
-const pb = new PocketBase('https://mmhs.pockethost.io');
-
 export default function CreatePost() {
   const [newPostTitle, setNewPostTitle] = useState('');
   const [newPostBody, setNewPostBody] = useState('');
   const [submitting, setSubmitting] = useState(false);
+  const [session, setSession] = useState<Session | null>(null);
+  const [checkedSession, setCheckedSession] = useState(false);
   // Ref, not state: setSubmitting only lands on the next render, so rapid clicks
   // would all read submitting === false and each fire a create().
   const submittingRef = useRef(false);
   const { push } = useRouter();
 
   useEffect(() => {
-    if (!pb.authStore.isValid) {
-      push('/login');
-    }
+    supabase.auth.getSession().then(({ data }) => {
+      setSession(data.session);
+      setCheckedSession(true);
+      if (!data.session) push('/login');
+    });
+    const { data: listener } = supabase.auth.onAuthStateChange((_event, s) => {
+      setSession(s);
+      if (!s) push('/login');
+    });
+    return () => listener.subscription.unsubscribe();
   }, [push]);
 
   const handleCreatePost = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
-    if (!pb.authStore.isValid) {
+    if (!session) {
       toast.warning('You need to log in to create a post.');
       push('/login');
       return;
     }
     if (submittingRef.current) return;
 
-    if (!pb.authStore.model) {
-      toast.warning('Session expired. Please log in again.');
-      push('/login');
-      return;
-    }
-
     submittingRef.current = true;
     setSubmitting(true);
-    const authorId = pb.authStore.model.id;
     try {
-      const createdPost = await pb.collection('posts').create(
-        {
-          title: newPostTitle,
-          body: newPostBody,
-          author: authorId,
-          upvotes: 0,
-        },
-        { requestKey: null } // opt out of auto-cancellation; see PostPageClient
-      );
-
+      const res = await apiFetch('/forum/posts', {
+        method: 'POST',
+        body: JSON.stringify({ title: newPostTitle, content: newPostBody }),
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(body.error ?? `Failed to create post (${res.status})`);
+      }
+      const createdPost = (await res.json()) as { id: string };
       toast.success('Post created.');
       push(`/forum/${createdPost.id}`);
     } catch (error) {
-      const err = error as { isAbort?: boolean };
-
-      // The post actually saved; PocketHost's broken hook just reports 400, and it
-      // swallows the created record with it. Look the post back up so we can still
-      // land the user on it. See lib/pocketbase-bug.ts.
-      if (isPostCommitHookBug(error)) {
-        toast.success('Post created.');
-        try {
-          const recent = await pb.collection('posts').getList(1, 1, {
-            filter: `author="${authorId}"`,
-            sort: '-created',
-            requestKey: null,
-          });
-          const id = recent.items[0]?.id;
-          push(id ? `/forum/${id}` : '/forum');
-        } catch {
-          push('/forum');
-        }
-        return;
-      }
-
-      if (!err.isAbort) {
-        console.error('Error creating post:', error);
-        toast.error('Could not create the post.');
-      }
+      console.error('Error creating post:', error);
+      toast.error('Could not create the post.');
       submittingRef.current = false;
       setSubmitting(false);
     }
@@ -118,6 +94,10 @@ export default function CreatePost() {
     'image',
     'code-block',
   ];
+
+  if (checkedSession && !session) {
+    return null;
+  }
 
   return (
     <div className="bg-background text-foreground">

--- a/website/app/forum/[id]/PostPageClient.tsx
+++ b/website/app/forum/[id]/PostPageClient.tsx
@@ -119,7 +119,7 @@ export default function PostPageClient({ id }: Props) {
     const delta = cancelling ? -value : value - current;
 
     setComments((prev) =>
-      prev.map((c) => (c.id === commentId ? { ...c, score: c.score + delta } : c)),
+      prev.map((c) => (c.id === commentId ? { ...c, score: c.score + delta } : c))
     );
     setCommentVotes((prev) => ({ ...prev, [commentId]: cancelling ? 0 : value }));
 
@@ -138,7 +138,7 @@ export default function PostPageClient({ id }: Props) {
       console.error('Error voting on comment:', error);
       toast.error('Could not register your vote.');
       setComments((prev) =>
-        prev.map((c) => (c.id === commentId ? { ...c, score: c.score - delta } : c)),
+        prev.map((c) => (c.id === commentId ? { ...c, score: c.score - delta } : c))
       );
       setCommentVotes((prev) => ({ ...prev, [commentId]: current }));
     }

--- a/website/app/forum/[id]/PostPageClient.tsx
+++ b/website/app/forum/[id]/PostPageClient.tsx
@@ -2,88 +2,145 @@
 
 import React, { useState, useEffect, useCallback, useRef } from 'react';
 import Link from 'next/link';
-import PocketBase, { RecordModel } from 'pocketbase';
 import { ArrowLeftIcon, ArrowUpIcon, ArrowDownIcon } from '@radix-ui/react-icons';
 import { toast } from 'sonner';
-import { isPostCommitHookBug } from '../../../lib/pocketbase-bug';
 import { Button } from '../../../components/ui/button';
 import { Card, CardContent } from '../../../components/ui/card';
 import { SectionContainer } from '../../../components/ui/section-container';
+import { supabase, apiFetch } from '../../../lib/supabase';
+import type { Session } from '@supabase/supabase-js';
 import dynamic from 'next/dynamic';
 
 const ReactQuill = dynamic(() => import('react-quill-new'), { ssr: false });
 import 'react-quill-new/dist/quill.bubble.css';
 
-const pb = new PocketBase('https://mmhs.pockethost.io');
+type PostDetail = {
+  id: string;
+  title: string;
+  content: string;
+  score: number;
+  createdAt: string;
+  author: { username: string | null };
+};
+
+type CommentRow = {
+  id: string;
+  content: string;
+  score: number;
+  createdAt: string;
+  author: { username: string | null };
+};
 
 type Props = {
   id: string;
-  initialPost: RecordModel | null;
 };
 
-export default function PostPageClient({ id, initialPost }: Props) {
-  const [post, setPost] = useState<RecordModel | null>(initialPost);
-  const [comments, setComments] = useState<RecordModel[]>([]);
+export default function PostPageClient({ id }: Props) {
+  const [post, setPost] = useState<PostDetail | null>(null);
+  const [comments, setComments] = useState<CommentRow[]>([]);
   const [newComment, setNewComment] = useState('');
-  const [isLoggedIn, setIsLoggedIn] = useState(false);
+  const [session, setSession] = useState<Session | null>(null);
+  const [postVote, setPostVote] = useState<1 | -1 | 0>(0);
+  const [commentVotes, setCommentVotes] = useState<Record<string, 1 | -1 | 0>>({});
   const [submitting, setSubmitting] = useState(false);
   // The guard has to be a ref, not the state above: setSubmitting doesn't apply
   // until the next render, so back-to-back clicks in one frame would all read
   // submitting === false and each fire a create(). A ref writes synchronously.
   const submittingRef = useRef(false);
 
+  const isLoggedIn = !!session;
+
+  useEffect(() => {
+    supabase.auth.getSession().then(({ data }) => setSession(data.session));
+    const { data: listener } = supabase.auth.onAuthStateChange((_event, s) => setSession(s));
+    return () => listener.subscription.unsubscribe();
+  }, []);
+
   const fetchPost = useCallback(async () => {
     try {
-      const record = await pb.collection('posts').getOne(id, {
-        expand: 'author',
-        requestKey: `post_${id}`,
-      });
-      setPost(record);
+      const res = await apiFetch(`/forum/posts/${id}`);
+      if (!res.ok) return;
+      const { post: p, comments: c } = (await res.json()) as {
+        post: PostDetail;
+        comments: CommentRow[];
+      };
+      setPost(p);
+      setComments(c);
     } catch (error) {
-      const err = error as { isAbort?: boolean };
-      if (!err.isAbort) console.error('Error fetching post:', error);
-    }
-  }, [id]);
-
-  const fetchComments = useCallback(async () => {
-    try {
-      const resultList = await pb.collection('comments').getList(1, 50, {
-        filter: `post="${id}"`,
-        sort: '-created',
-        expand: 'author',
-        requestKey: `comments_${id}`,
-      });
-      setComments(resultList.items);
-    } catch (error) {
-      const err = error as { isAbort?: boolean };
-      if (!err.isAbort) console.error('Error fetching comments:', error);
+      console.error('Error fetching post:', error);
     }
   }, [id]);
 
   useEffect(() => {
-    setIsLoggedIn(pb.authStore.isValid);
     fetchPost();
-    fetchComments();
-  }, [id, fetchPost, fetchComments]);
+  }, [id, fetchPost]);
 
-  // NOTE: remove the old `document.title` effect — the server now
-  // sets the real <title> via generateMetadata, and manually
-  // overwriting it client-side would fight with that.
-
-  const handleVote = async (voteType: 'upvote' | 'downvote') => {
+  const handlePostVote = async (value: 1 | -1) => {
     if (!isLoggedIn) {
       toast.warning('Please log in to vote.');
       return;
     }
     if (!post) return;
 
+    const cancelling = postVote === value;
+    const delta = cancelling ? -value : value - postVote;
+    const prevVote = postVote;
+
+    setPost((p) => (p ? { ...p, score: p.score + delta } : null));
+    setPostVote(cancelling ? 0 : value);
+
     try {
-      const updatedVotes = post.upvotes + (voteType === 'upvote' ? 1 : -1);
-      await pb.collection('posts').update(id, { upvotes: updatedVotes });
-      setPost((prev) => (prev ? { ...prev, upvotes: updatedVotes } : null));
+      const res = cancelling
+        ? await apiFetch('/forum/vote', {
+            method: 'DELETE',
+            body: JSON.stringify({ votableType: 'post', votableId: id }),
+          })
+        : await apiFetch('/forum/vote', {
+            method: 'POST',
+            body: JSON.stringify({ votableType: 'post', votableId: id, value }),
+          });
+      if (!res.ok) throw new Error(`Vote failed (${res.status})`);
     } catch (error) {
       console.error('Error voting on post:', error);
       toast.error('Could not register your vote.');
+      setPost((p) => (p ? { ...p, score: p.score - delta } : null));
+      setPostVote(prevVote);
+    }
+  };
+
+  const handleCommentVote = async (commentId: string, value: 1 | -1) => {
+    if (!isLoggedIn) {
+      toast.warning('Please log in to vote.');
+      return;
+    }
+
+    const current = commentVotes[commentId] ?? 0;
+    const cancelling = current === value;
+    const delta = cancelling ? -value : value - current;
+
+    setComments((prev) =>
+      prev.map((c) => (c.id === commentId ? { ...c, score: c.score + delta } : c)),
+    );
+    setCommentVotes((prev) => ({ ...prev, [commentId]: cancelling ? 0 : value }));
+
+    try {
+      const res = cancelling
+        ? await apiFetch('/forum/vote', {
+            method: 'DELETE',
+            body: JSON.stringify({ votableType: 'comment', votableId: commentId }),
+          })
+        : await apiFetch('/forum/vote', {
+            method: 'POST',
+            body: JSON.stringify({ votableType: 'comment', votableId: commentId, value }),
+          });
+      if (!res.ok) throw new Error(`Vote failed (${res.status})`);
+    } catch (error) {
+      console.error('Error voting on comment:', error);
+      toast.error('Could not register your vote.');
+      setComments((prev) =>
+        prev.map((c) => (c.id === commentId ? { ...c, score: c.score - delta } : c)),
+      );
+      setCommentVotes((prev) => ({ ...prev, [commentId]: current }));
     }
   };
 
@@ -95,39 +152,23 @@ export default function PostPageClient({ id, initialPost }: Props) {
     }
     if (submittingRef.current) return;
 
-    if (!pb.authStore.model) {
-      toast.warning('Session expired. Please log in again.');
-      return;
-    }
-
     submittingRef.current = true;
     setSubmitting(true);
 
-    // Only the create() decides success. Anything after it (refetching the list)
-    // must not be able to trigger the failure toast: that's how a comment could
-    // post fine and still report "Could not post your comment".
     let created = false;
     try {
-      // requestKey: null opts out of PocketBase's auto-cancellation, which aborts
-      // a duplicate in-flight request client-side while the server still commits it.
-      await pb.collection('comments').create(
-        {
-          body: newComment,
-          post: id,
-          author: pb.authStore.model.id,
-        },
-        { requestKey: null }
-      );
+      const res = await apiFetch(`/forum/posts/${id}/comments`, {
+        method: 'POST',
+        body: JSON.stringify({ content: newComment }),
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(body.error ?? `Failed to post comment (${res.status})`);
+      }
       created = true;
     } catch (error) {
-      const err = error as { isAbort?: boolean };
-      // The comment actually posted; PocketHost's broken hook just reports 400. See lib/pocketbase-bug.ts.
-      if (isPostCommitHookBug(error)) {
-        created = true;
-      } else if (!err.isAbort) {
-        console.error('Error adding comment:', error);
-        toast.error('Could not post your comment.');
-      }
+      console.error('Error adding comment:', error);
+      toast.error('Could not post your comment.');
     } finally {
       submittingRef.current = false;
       setSubmitting(false);
@@ -136,7 +177,7 @@ export default function PostPageClient({ id, initialPost }: Props) {
     if (created) {
       setNewComment('');
       toast.success('Comment posted.');
-      fetchComments(); // handles its own errors; must not affect the toast above
+      fetchPost(); // handles its own errors; must not affect the toast above
     }
   };
 
@@ -168,7 +209,7 @@ export default function PostPageClient({ id, initialPost }: Props) {
             </h1>
 
             <ReactQuill
-              value={post.body}
+              value={post.content}
               readOnly
               theme="bubble"
               className="text-foreground-light leading-relaxed mb-4"
@@ -178,26 +219,34 @@ export default function PostPageClient({ id, initialPost }: Props) {
               <span className="text-sm text-foreground-lighter">
                 By{' '}
                 <span className="font-semibold text-foreground-light">
-                  {post.expand?.author?.username || 'Unknown'}
+                  {post.author?.username ?? 'Unknown'}
                 </span>{' '}
-                on {new Date(post.created).toISOString().split('T')[0]}
+                on {new Date(post.createdAt).toISOString().split('T')[0]}
               </span>
 
               <div className="flex items-center gap-2">
                 <button
-                  onClick={() => handleVote('upvote')}
+                  onClick={() => handlePostVote(1)}
                   disabled={!isLoggedIn}
                   aria-label="Upvote"
-                  className="text-foreground-lighter hover:text-brand disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                  className={`transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
+                    postVote === 1
+                      ? 'text-brand font-bold'
+                      : 'text-foreground-lighter hover:text-brand'
+                  }`}
                 >
                   <ArrowUpIcon width="16" height="16" />
                 </button>
-                <span className="font-semibold text-foreground">{post.upvotes}</span>
+                <span className="font-semibold text-foreground">{post.score}</span>
                 <button
-                  onClick={() => handleVote('downvote')}
+                  onClick={() => handlePostVote(-1)}
                   disabled={!isLoggedIn}
                   aria-label="Downvote"
-                  className="text-foreground-lighter hover:text-destructive disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                  className={`transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
+                    postVote === -1
+                      ? 'text-destructive font-bold'
+                      : 'text-foreground-lighter hover:text-destructive'
+                  }`}
                 >
                   <ArrowDownIcon width="16" height="16" />
                 </button>
@@ -214,20 +263,54 @@ export default function PostPageClient({ id, initialPost }: Props) {
           {comments.length === 0 ? (
             <p className="text-sm text-foreground-lighter italic">No comments yet.</p>
           ) : (
-            comments.map((comment) => (
-              <Card key={comment.id}>
-                <CardContent className="p-5 border-none">
-                  <p className="text-foreground-light whitespace-pre-wrap">{comment.body}</p>
-                  <p className="mt-3 text-xs text-foreground-lighter">
-                    By{' '}
-                    <span className="font-medium text-foreground-light">
-                      {comment.expand?.author?.username || 'Unknown'}
-                    </span>{' '}
-                    on {new Date(comment.created).toISOString().split('T')[0]}
-                  </p>
-                </CardContent>
-              </Card>
-            ))
+            comments.map((comment) => {
+              const userVote = commentVotes[comment.id] ?? 0;
+              return (
+                <Card key={comment.id}>
+                  <CardContent className="p-5 border-none">
+                    <p className="text-foreground-light whitespace-pre-wrap">{comment.content}</p>
+                    <div className="mt-3 flex items-center justify-between flex-wrap gap-2">
+                      <p className="text-xs text-foreground-lighter">
+                        By{' '}
+                        <span className="font-medium text-foreground-light">
+                          {comment.author?.username ?? 'Unknown'}
+                        </span>{' '}
+                        on {new Date(comment.createdAt).toISOString().split('T')[0]}
+                      </p>
+                      <div className="flex items-center gap-1.5">
+                        <button
+                          onClick={() => handleCommentVote(comment.id, 1)}
+                          disabled={!isLoggedIn}
+                          aria-label="Upvote comment"
+                          className={`transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
+                            userVote === 1
+                              ? 'text-brand font-bold'
+                              : 'text-foreground-lighter hover:text-brand'
+                          }`}
+                        >
+                          <ArrowUpIcon width="12" height="12" />
+                        </button>
+                        <span className="text-xs font-semibold text-foreground">
+                          {comment.score}
+                        </span>
+                        <button
+                          onClick={() => handleCommentVote(comment.id, -1)}
+                          disabled={!isLoggedIn}
+                          aria-label="Downvote comment"
+                          className={`transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
+                            userVote === -1
+                              ? 'text-destructive font-bold'
+                              : 'text-foreground-lighter hover:text-destructive'
+                          }`}
+                        >
+                          <ArrowDownIcon width="12" height="12" />
+                        </button>
+                      </div>
+                    </div>
+                  </CardContent>
+                </Card>
+              );
+            })
           )}
         </div>
 

--- a/website/app/forum/[id]/page.tsx
+++ b/website/app/forum/[id]/page.tsx
@@ -1,16 +1,28 @@
 import type { Metadata } from 'next';
-import { cache } from 'react';
-import PocketBase from 'pocketbase';
 import PostPageClient from './PostPageClient';
 
-const getPost = cache(async (id: string) => {
-  const pb = new PocketBase('https://mmhs.pockethost.io');
+type ApiPost = {
+  title: string;
+  content: string;
+  createdAt: string;
+  author: { username: string | null };
+};
+
+// GET /forum/posts/:id is public, so metadata generation can hit it directly
+// with plain fetch — no JWT needed, and apiFetch only works client-side anyway
+// (it reads the session from the browser's local storage).
+const apiBase = process.env.NEXT_PUBLIC_API_URL ?? 'https://api.cccsolutions.ca';
+
+async function getPost(id: string): Promise<ApiPost | null> {
   try {
-    return await pb.collection('posts').getOne(id, { expand: 'author' });
+    const res = await fetch(`${apiBase}/forum/posts/${id}`, { next: { revalidate: 60 } });
+    if (!res.ok) return null;
+    const { post } = (await res.json()) as { post: ApiPost };
+    return post;
   } catch {
     return null;
   }
-});
+}
 
 type Props = {
   params: Promise<{ id: string }>;
@@ -24,8 +36,8 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     return { title: 'Post Not Found | CCC Forum' };
   }
 
-  const authorName = post.expand?.author?.username || 'Unknown';
-  const plainBody = (post.body || '').replace(/<[^>]*>/g, '').trim();
+  const authorName = post.author?.username ?? 'Unknown';
+  const plainBody = (post.content || '').replace(/<[^>]*>/g, '').trim();
   const description =
     plainBody.length > 155
       ? plainBody.slice(0, 155) + '…'
@@ -44,8 +56,8 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       description,
       url: `https://cccsolutions.ca/forum/${id}`,
       type: 'article',
-      authors: post.expand?.author?.username ? [post.expand.author.username] : undefined,
-      publishedTime: post.created,
+      authors: post.author?.username ? [post.author.username] : undefined,
+      publishedTime: post.createdAt,
     },
     twitter: {
       card: 'summary_large_image',
@@ -57,7 +69,5 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
 export default async function Page({ params }: Props) {
   const { id } = await params;
-  const post = await getPost(id);
-
-  return <PostPageClient id={id} initialPost={post} />;
+  return <PostPageClient id={id} />;
 }

--- a/website/app/forum/page.tsx
+++ b/website/app/forum/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 
-import React, { useState, useEffect } from 'react';
-import PocketBase, { RecordModel, AuthModel } from 'pocketbase';
+import React, { useState, useEffect, useCallback } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { ArrowUpIcon, ArrowDownIcon } from '@radix-ui/react-icons';
@@ -10,74 +9,93 @@ import { Button } from '../../components/ui/button';
 import { Card } from '../../components/ui/card';
 import { SectionContainer } from '../../components/ui/section-container';
 import { FlickeringGrid } from '../../components/effects/FlickeringGrid';
+import { supabase, apiFetch } from '../../lib/supabase';
+import type { Session } from '@supabase/supabase-js';
 import dynamic from 'next/dynamic';
 
 const ReactQuill = dynamic(() => import('react-quill-new'), { ssr: false });
 import 'react-quill-new/dist/quill.bubble.css';
 
-const pb = new PocketBase('https://mmhs.pockethost.io');
+type PostRow = {
+  id: string;
+  title: string;
+  content: string;
+  score: number;
+  createdAt: string;
+  author: { username: string | null };
+};
+
+// Tracks the current user's vote on each post so the arrows reflect their state.
+type VoteMap = Record<string, 1 | -1 | 0>;
 
 export default function ForumPage() {
-  const [posts, setPosts] = useState<RecordModel[]>([]);
+  const [posts, setPosts] = useState<PostRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [sortBy, setSortBy] = useState<'new' | 'top'>('new');
-  const [user, setUser] = useState<AuthModel | null>(null);
+  const [voteMap, setVoteMap] = useState<VoteMap>({});
+  const [session, setSession] = useState<Session | null>(null);
 
   const { push } = useRouter();
 
   useEffect(() => {
-    setUser(pb.authStore.model);
+    supabase.auth.getSession().then(({ data }) => setSession(data.session));
+    const { data: listener } = supabase.auth.onAuthStateChange((_event, s) => setSession(s));
+    return () => listener.subscription.unsubscribe();
   }, []);
 
-  useEffect(() => {
-    const fetchPosts = async () => {
-      try {
-        setLoading(true);
-        const sortField = sortBy === 'new' ? '-created' : '-upvotes';
-        const resultList = await pb.collection('posts').getList(1, 50, {
-          sort: sortField,
-          expand: 'author',
-          requestKey: `posts_${sortField}`,
-        });
-        setPosts(resultList.items);
-      } catch (error: unknown) {
-        const err = error as { isAbort?: boolean };
-        if (!err.isAbort) {
-          console.error('Error fetching posts:', error);
-        }
-      } finally {
-        setLoading(false);
-      }
-    };
-    fetchPosts();
+  const fetchPosts = useCallback(async () => {
+    try {
+      setLoading(true);
+      const res = await apiFetch(`/forum/posts?sort=${sortBy}`);
+      if (!res.ok) throw new Error(`Failed to load posts (${res.status})`);
+      const data = (await res.json()) as PostRow[];
+      setPosts(data);
+    } catch (error) {
+      console.error('Error fetching posts:', error);
+      toast.error('Could not load posts.');
+    } finally {
+      setLoading(false);
+    }
   }, [sortBy]);
 
-  const handleVote = async (postId: string, voteType: 'upvote' | 'downvote') => {
-    if (!user) {
+  useEffect(() => {
+    fetchPosts();
+  }, [fetchPosts]);
+
+  const handleVote = async (postId: string, value: 1 | -1) => {
+    if (!session) {
       toast.warning('Please log in to vote.');
       return;
     }
+
+    const current = voteMap[postId] ?? 0;
+    const cancelling = current === value;
+    const delta = cancelling ? -value : value - current;
+
+    setPosts((prev) => prev.map((p) => (p.id === postId ? { ...p, score: p.score + delta } : p)));
+    setVoteMap((prev) => ({ ...prev, [postId]: cancelling ? 0 : value }));
+
     try {
-      const post = posts.find((p) => p.id === postId);
-      if (!post) return;
-      const updatedVotes = voteType === 'upvote' ? post.upvotes + 1 : post.upvotes - 1;
-      await pb.collection('posts').update(postId, { upvotes: updatedVotes });
-      setPosts((prev) => {
-        const next = prev.map((p) => (p.id === postId ? { ...p, upvotes: updatedVotes } : p));
-        if (sortBy === 'top') {
-          next.sort((a, b) => b.upvotes - a.upvotes);
-        }
-        return next;
-      });
+      const res = cancelling
+        ? await apiFetch('/forum/vote', {
+            method: 'DELETE',
+            body: JSON.stringify({ votableType: 'post', votableId: postId }),
+          })
+        : await apiFetch('/forum/vote', {
+            method: 'POST',
+            body: JSON.stringify({ votableType: 'post', votableId: postId, value }),
+          });
+      if (!res.ok) throw new Error(`Vote failed (${res.status})`);
     } catch (error) {
       console.error('Error voting on post:', error);
       toast.error('Could not register your vote.');
+      setPosts((prev) => prev.map((p) => (p.id === postId ? { ...p, score: p.score - delta } : p)));
+      setVoteMap((prev) => ({ ...prev, [postId]: current }));
     }
   };
 
-  const handleLogout = () => {
-    pb.authStore.clear();
-    setUser(null);
+  const handleLogout = async () => {
+    await supabase.auth.signOut();
   };
 
   return (
@@ -110,9 +128,9 @@ export default function ForumPage() {
       {/* Login status — moved below the hero, right-aligned */}
       <SectionContainer size="large" className="pt-4">
         <div className="flex justify-end text-sm text-foreground-light">
-          {user ? (
+          {session ? (
             <span>
-              Logged in as <span className="font-semibold text-foreground">{user.username}</span>
+              Logged in
               {' · '}
               <button
                 className="cursor-pointer underline hover:text-foreground"
@@ -175,49 +193,62 @@ export default function ForumPage() {
           </div>
         ) : (
           <div className="flex flex-col gap-2">
-            {posts.map((post) => (
-              <Card key={post.id} className="hover:bg-surface-200/40 transition-colors">
-                <div className="flex gap-4 px-5 py-4">
-                  <div className="flex flex-col items-center justify-start gap-1 pt-1 shrink-0 w-10">
-                    <button
-                      onClick={() => handleVote(post.id, 'upvote')}
-                      disabled={!user}
-                      aria-label="Upvote"
-                      className="text-foreground-lighter hover:text-brand disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-                    >
-                      <ArrowUpIcon width="16" height="16" />
-                    </button>
-                    <span className="text-sm font-semibold text-foreground">{post.upvotes}</span>
-                    <button
-                      onClick={() => handleVote(post.id, 'downvote')}
-                      disabled={!user}
-                      aria-label="Downvote"
-                      className="text-foreground-lighter hover:text-destructive disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-                    >
-                      <ArrowDownIcon width="16" height="16" />
-                    </button>
-                  </div>
+            {posts.map((post) => {
+              const userVote = voteMap[post.id] ?? 0;
+              return (
+                <Card key={post.id} className="hover:bg-surface-200/40 transition-colors">
+                  <div className="flex gap-4 px-5 py-4">
+                    <div className="flex flex-col items-center justify-start gap-1 pt-1 shrink-0 w-10">
+                      <button
+                        onClick={() => handleVote(post.id, 1)}
+                        disabled={!session}
+                        aria-label="Upvote"
+                        className={`transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
+                          userVote === 1
+                            ? 'text-brand font-bold'
+                            : 'text-foreground-lighter hover:text-brand'
+                        }`}
+                      >
+                        <ArrowUpIcon width="16" height="16" />
+                      </button>
+                      <span className="text-sm font-semibold text-foreground">{post.score}</span>
+                      <button
+                        onClick={() => handleVote(post.id, -1)}
+                        disabled={!session}
+                        aria-label="Downvote"
+                        className={`transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
+                          userVote === -1
+                            ? 'text-destructive font-bold'
+                            : 'text-foreground-lighter hover:text-destructive'
+                        }`}
+                      >
+                        <ArrowDownIcon width="16" height="16" />
+                      </button>
+                    </div>
 
-                  <div className="flex-1 min-w-0">
-                    <h2 className="text-lg font-semibold text-foreground hover:text-brand transition-colors mb-1">
-                      <Link href={`/forum/${post.id}`}>{post.title}</Link>
-                    </h2>
-                    <ReactQuill
-                      value={
-                        post.body.length > 200 ? post.body.substring(0, 200) + '...' : post.body
-                      }
-                      readOnly
-                      theme="bubble"
-                      className="text-foreground-light max-h-24 overflow-hidden"
-                    />
-                    <div className="mt-2 text-xs text-foreground-lighter">
-                      By {post.expand?.author?.username || 'Unknown'} ·{' '}
-                      {new Date(post.created).toLocaleDateString()}
+                    <div className="flex-1 min-w-0">
+                      <h2 className="text-lg font-semibold text-foreground hover:text-brand transition-colors mb-1">
+                        <Link href={`/forum/${post.id}`}>{post.title}</Link>
+                      </h2>
+                      <ReactQuill
+                        value={
+                          post.content.length > 200
+                            ? post.content.substring(0, 200) + '...'
+                            : post.content
+                        }
+                        readOnly
+                        theme="bubble"
+                        className="text-foreground-light max-h-24 overflow-hidden"
+                      />
+                      <div className="mt-2 text-xs text-foreground-lighter">
+                        By {post.author?.username ?? 'Unknown'} ·{' '}
+                        {new Date(post.createdAt).toLocaleDateString()}
+                      </div>
                     </div>
                   </div>
-                </div>
-              </Card>
-            ))}
+                </Card>
+              );
+            })}
           </div>
         )}
       </SectionContainer>

--- a/website/bun.lock
+++ b/website/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "cccsolutions-website",
@@ -9,6 +8,7 @@
         "@radix-ui/react-icons": "^1.3.2",
         "@radix-ui/react-slot": "^1.3.0",
         "@radix-ui/themes": "^3.3.0",
+        "@supabase/supabase-js": "^2.112.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "highlight.js": "^11.11.1",
@@ -679,6 +679,20 @@
 
     "@speed-highlight/core": ["@speed-highlight/core@1.2.17", "", {}, "sha512-Z92FwKpCtfaW1V0jTU/fh3QzYEZN8wDwrzRIBoADCJfn4mJCNcJN/XegifX7BDrQ8/h9Xh/JnbyMchL0FqXrkg=="],
 
+    "@supabase/auth-js": ["@supabase/auth-js@2.112.2", "", { "dependencies": { "tslib": "2.8.1" } }, "sha512-l1InCp4j98d09LZ6+RgubgF4eVPGBGXcLEhFusLg1qUCHJ2IEkYu5FohKK+eaFmIOwEk0kqG/j/lycw5e15mcQ=="],
+
+    "@supabase/functions-js": ["@supabase/functions-js@2.112.2", "", { "dependencies": { "tslib": "2.8.1" } }, "sha512-oMuSWN0ERmrG9S6kOM0bwhHmESGVl3kMtkZl2dNCU/r89hMiziX4GfD1omNo9QcBDele4N0GwSZ7hdbpuiA35A=="],
+
+    "@supabase/phoenix": ["@supabase/phoenix@0.4.5", "", {}, "sha512-aAn9H9ovVyeApKy11OWOrrOGq8DV68yWeH4ud2lN9fzn4aO8Zb5GLL9m1pUg9nLqIcT+ZDfAcsZe0E/nqdv2lw=="],
+
+    "@supabase/postgrest-js": ["@supabase/postgrest-js@2.112.2", "", { "dependencies": { "tslib": "2.8.1" } }, "sha512-ewhhtRny/HFRGhUTTg/PsqIatsl8OhW8Eha/Tz4S+SRAXBnuhKei9ZpsQTgL/3XcH9UEwuPQyQgQ9itq7nRQeg=="],
+
+    "@supabase/realtime-js": ["@supabase/realtime-js@2.112.2", "", { "dependencies": { "@supabase/phoenix": "0.4.5", "tslib": "2.8.1" } }, "sha512-cd9/CEUJ6Go13FxtfiuC5rYELJtuQzVzTXlGG+XjSppjDS+anq+xo++WQe7ZRUNTuHOCeyKRwmx9Hw/OQJ04ig=="],
+
+    "@supabase/storage-js": ["@supabase/storage-js@2.112.2", "", { "dependencies": { "iceberg-js": "^0.8.1", "tslib": "2.8.1" } }, "sha512-6jyBq/J1iXOHNpbjCZS7gFcDk49iM1MCJUVkDl71gLd/+XnLDzpUBs8icGebtwiHpl4kVszxIRDYAosbF4Rsig=="],
+
+    "@supabase/supabase-js": ["@supabase/supabase-js@2.112.2", "", { "dependencies": { "@supabase/auth-js": "2.112.2", "@supabase/functions-js": "2.112.2", "@supabase/postgrest-js": "2.112.2", "@supabase/realtime-js": "2.112.2", "@supabase/storage-js": "2.112.2" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-UyI1epU9B4X51HvNpkmlwTdF20fEcz2vyvrcDKVzFN4jZN41f5iQRqsiIQjAY5OVJD6ljqA/1g9JQeOTvFHpkA=="],
+
     "@swc/helpers": ["@swc/helpers@0.5.15", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g=="],
 
     "@tailwindcss/node": ["@tailwindcss/node@4.3.2", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "5.21.6", "jiti": "^2.7.0", "lightningcss": "1.32.0", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.3.2" } }, "sha512-yWP/sqEcBLaD8JuA6zNwxoYKr75qxTioYwlRwekj5Jr/I5GXnoJfjetH/psLUIv74cYTH2lBUEzBkinthoYcBg=="],
@@ -1298,6 +1312,8 @@
     "human-signals": ["human-signals@2.1.0", "", {}, "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw=="],
 
     "humanize-ms": ["humanize-ms@1.2.1", "", { "dependencies": { "ms": "^2.0.0" } }, "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ=="],
+
+    "iceberg-js": ["iceberg-js@0.8.1", "", {}, "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA=="],
 
     "iconv-lite": ["iconv-lite@0.7.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ=="],
 

--- a/website/lib/supabase.ts
+++ b/website/lib/supabase.ts
@@ -13,7 +13,7 @@ const supabasePublishableKey = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!
 
 if (!supabaseUrl || !supabasePublishableKey) {
   throw new Error(
-    'Missing NEXT_PUBLIC_SUPABASE_URL or NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY environment variable.',
+    'Missing NEXT_PUBLIC_SUPABASE_URL or NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY environment variable.'
   );
 }
 

--- a/website/lib/supabase.ts
+++ b/website/lib/supabase.ts
@@ -1,0 +1,48 @@
+// Supabase browser client — used in client components for:
+//   1. Email/password + Google OAuth sign-in
+//   2. Session management (getSession, onAuthStateChange)
+//   3. Getting the JWT to pass as Authorization: Bearer to our Hono API
+//
+// The frontend NEVER calls Supabase directly for data (posts/comments/votes).
+// All data goes through the Hono API at NEXT_PUBLIC_API_URL.
+
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+const supabasePublishableKey = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!;
+
+if (!supabaseUrl || !supabasePublishableKey) {
+  throw new Error(
+    'Missing NEXT_PUBLIC_SUPABASE_URL or NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY environment variable.',
+  );
+}
+
+export const supabase = createClient(supabaseUrl, supabasePublishableKey);
+
+/** Returns the current session's access_token (JWT) or null if not logged in. */
+export async function getAccessToken(): Promise<string | null> {
+  const { data } = await supabase.auth.getSession();
+  return data.session?.access_token ?? null;
+}
+
+/** Convenience: returns Authorization header value or null. */
+export async function authHeader(): Promise<Record<string, string>> {
+  const token = await getAccessToken();
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+// ---------------------------------------------------------------------------
+// API helper — calls the Hono backend with the user's JWT attached.
+// ---------------------------------------------------------------------------
+
+const apiBase = process.env.NEXT_PUBLIC_API_URL ?? 'https://api.cccsolutions.ca';
+
+export async function apiFetch(path: string, init: RequestInit = {}): Promise<Response> {
+  const headers = new Headers(init.headers);
+  const token = await getAccessToken();
+  if (token) headers.set('Authorization', `Bearer ${token}`);
+  if (!headers.has('Content-Type') && init.body && typeof init.body === 'string') {
+    headers.set('Content-Type', 'application/json');
+  }
+  return fetch(`${apiBase}${path}`, { ...init, headers });
+}

--- a/website/package.json
+++ b/website/package.json
@@ -20,6 +20,7 @@
     "@radix-ui/react-icons": "^1.3.2",
     "@radix-ui/react-slot": "^1.3.0",
     "@radix-ui/themes": "^3.3.0",
+    "@supabase/supabase-js": "^2.112.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "highlight.js": "^11.11.1",


### PR DESCRIPTION
## Description

Migrates the forum's data layer off the old `mmhs.pockethost.io` PocketBase
instance onto the new Hono API (#197) with Supabase auth. This is
foundational: it wires up the Supabase browser client and env plumbing that
the real auth UI (follow-up PR) builds on.

Note: this PR is stacked on `feat/auth-oauth` (not `main`) because that
branch has the backend changes this depends on — username-from-signup
(`user_metadata.username`), Google OAuth, and the local ES256 JWT signing
key setup — which aren't on `main` yet. `feat/auth-oauth` is otherwise just
`main` + those two backend commits, so this should merge cleanly once that
branch lands.

## Changes

- `lib/supabase.ts`: browser Supabase client + `getAccessToken()` /
  `authHeader()` / `apiFetch()` helper (prod-safe fallback URL, since
  `NEXT_PUBLIC_API_URL` is only guaranteed to exist in `.env.local`/`.env.production`).
- `app/forum/page.tsx`, `app/forum/[id]/page.tsx` + `PostPageClient.tsx`,
  `app/create-post/page.tsx`: swapped PocketBase reads/writes for
  `apiFetch('/forum/...')`. UI/toast/structure preserved from `main`.
- Voting now goes through the real per-user vote endpoint
  (`POST`/`DELETE /forum/vote`) with optimistic UI + rollback, replacing the
  old naive `upvotes` counter increment (which had no per-user state and
  no way to un-vote).
- `.env.production` (committed — all values are `NEXT_PUBLIC_*`, i.e.
  public by design) and an updated `.env.local.example` with the Turnstile
  site key. `.env.local` itself is local-only and gitignored, pointed at
  the local Supabase stack.
- `website/package.json`: added `@supabase/supabase-js`.

Left alone in this PR (out of scope, still PocketBase-backed): `/login`
(`components/layout/Login.tsx`) and the `/forum/preview/*` mockup routes'
`AuthProvider` — both explicitly preview/legacy and get replaced by the
real auth UI in the follow-up PR. `pocketbase` stays a dependency until
that PR removes the last imports.

## Testing

- `bun run typecheck` and `bun run lint` — clean (only a pre-existing,
  unrelated font warning).
- Manual, in a real browser (Playwright), against the local stack
  (`supabase start` + `bun run dev` in `backend/` and `website/`):
  - `/forum` loads, hits `GET http://localhost:8787/forum/posts?sort=new`
    (verified via network log), renders the empty state correctly against
    an empty local DB — no PocketBase calls.
  - `/create-post` redirects an unauthenticated visitor to `/login`.
- Full signup → post → vote flow is exercised end-to-end in the follow-up
  PR once the auth UI exists.

## Linked issues

Refs #197, #198

## Checklist

- [x] I read CONTRIBUTING.md and gave my own code a once-over (it runs and does what the PR says)
- [x] `tsc`, lint, and tests pass locally (CI checks these too)
- [ ] New backend feature code (`backend/src/`) has vitest tests
- [x] Code is formatted and matches the surrounding style (CI checks this)
- [x] Docs/comments updated if behavior or APIs changed