### PR TITLE
test(backend): forum + user integration tests against local Supabase

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -11,6 +11,7 @@
     "format:check": "prettier --check \"src/**/*.ts\" \"test/**/*.ts\" \"vitest.config.ts\"",
     "test": "vitest run --coverage",
     "test:watch": "vitest",
+    "test:integration": "vitest run --config vitest.integration.config.ts",
     "typecheck": "tsc --noEmit",
     "db:pull": "drizzle-kit pull",
     "db:generate": "drizzle-kit generate",

--- a/backend/test/integration/env.ts
+++ b/backend/test/integration/env.ts
@@ -1,0 +1,60 @@
+// Shared setup for integration tests — talks to the LOCAL Supabase stack only.
+// Run with: supabase start && bun run db:migrate && bun run test:integration
+import { config } from 'dotenv';
+import { execSync } from 'node:child_process';
+import postgres from 'postgres';
+
+config({ path: '.dev.vars' });
+
+export const env = {
+  DATABASE_URL: process.env.DATABASE_URL ?? '',
+  SUPABASE_URL: process.env.SUPABASE_URL ?? '',
+};
+
+export async function isDbReachable(): Promise<boolean> {
+  if (!env.DATABASE_URL) return false;
+  const sql = postgres(env.DATABASE_URL, { max: 1, prepare: false, connect_timeout: 3 });
+  try {
+    await sql`select 1`;
+    return true;
+  } catch {
+    return false;
+  } finally {
+    await sql.end({ timeout: 1 });
+  }
+}
+
+let publishableKey: string | null = null;
+function getPublishableKey(): string {
+  if (publishableKey) return publishableKey;
+  const out = execSync('supabase status -o json', { stdio: ['ignore', 'pipe', 'ignore'] }).toString();
+  publishableKey = (JSON.parse(out.slice(out.indexOf('{'))) as { PUBLISHABLE_KEY: string }).PUBLISHABLE_KEY;
+  return publishableKey;
+}
+
+let counter = 0;
+
+// Signs up a fresh user against the local Supabase auth stack and returns a real
+// access token. Email confirmations are off locally, so signup returns a session
+// immediately (see supabase/config.toml on this branch).
+export async function signUp(
+  prefix = 'itest',
+): Promise<{ accessToken: string; userId: string; email: string; username: string }> {
+  const unique = `${Date.now()}_${process.pid}_${counter++}`;
+  const email = `${prefix}_${unique}@example.com`;
+  const username = `${prefix}${unique}`.replace(/[^a-z0-9_]/gi, '').slice(0, 24);
+  const res = await fetch(`${env.SUPABASE_URL}/auth/v1/signup`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', apikey: getPublishableKey() },
+    body: JSON.stringify({ email, password: 'password123!', data: { username } }),
+  });
+  if (!res.ok) throw new Error(`signup failed: ${res.status} ${await res.text()}`);
+  const body = (await res.json()) as { access_token?: string; user?: { id: string } };
+  if (!body.access_token || !body.user)
+    throw new Error('signup did not return a session — is enable_confirmations off?');
+  return { accessToken: body.access_token, userId: body.user.id, email, username };
+}
+
+export function authHeader(accessToken: string) {
+  return { Authorization: `Bearer ${accessToken}` };
+}

--- a/backend/test/integration/forum.test.ts
+++ b/backend/test/integration/forum.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { decodeJwt } from 'jose';
+import { app } from '../../src/index';
+import { getDb, withUser } from '../../src/db';
+import { posts } from '../../src/db/schema';
+import type { Bindings } from '../../src/types';
+import { env, isDbReachable, signUp, authHeader } from './env';
+
+const dbUp = await isDbReachable();
+
+describe.skipIf(!dbUp)('forum routes (integration, local Supabase)', () => {
+  let userA: Awaited<ReturnType<typeof signUp>>;
+  let userB: Awaited<ReturnType<typeof signUp>>;
+  let postId: string;
+
+  beforeAll(async () => {
+    userA = await signUp('forumA');
+    userB = await signUp('forumB');
+
+    const res = await app.request(
+      '/forum/posts',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...authHeader(userA.accessToken) },
+        body: JSON.stringify({ title: `seed post ${Date.now()}`, content: 'seed content' }),
+      },
+      env,
+    );
+    const post = (await res.json()) as { id: string };
+    postId = post.id;
+  });
+
+  it('GET /forum/posts returns an array, default and sort=new and sort=top', async () => {
+    for (const qs of ['', '?sort=new', '?sort=top']) {
+      const res = await app.request(`/forum/posts${qs}`, {}, env);
+      expect(res.status).toBe(200);
+      expect(Array.isArray(await res.json())).toBe(true);
+    }
+  });
+
+  it('GET /forum/posts/:id returns a known post', async () => {
+    const res = await app.request(`/forum/posts/${postId}`, {}, env);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { post: { id: string } };
+    expect(body.post.id).toBe(postId);
+  });
+
+  it('GET /forum/posts/:id returns 404 for an unknown uuid', async () => {
+    const res = await app.request('/forum/posts/00000000-0000-0000-0000-000000000000', {}, env);
+    expect(res.status).toBe(404);
+  });
+
+  it('POST /forum/posts returns 401 without Authorization', async () => {
+    const res = await app.request(
+      '/forum/posts',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title: 'x', content: 'y' }),
+      },
+      env,
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it('POST /forum/posts with a JWT returns 201 and the created post', async () => {
+    const title = `new post ${Date.now()}`;
+    const res = await app.request(
+      '/forum/posts',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...authHeader(userA.accessToken) },
+        body: JSON.stringify({ title, content: 'new content' }),
+      },
+      env,
+    );
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { title: string; content: string };
+    expect(body.title).toBe(title);
+    expect(body.content).toBe('new content');
+  });
+
+  it('POST /forum/posts/:id/comments with a JWT returns 201', async () => {
+    const res = await app.request(
+      `/forum/posts/${postId}/comments`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...authHeader(userB.accessToken) },
+        body: JSON.stringify({ content: 'nice post' }),
+      },
+      env,
+    );
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { content: string };
+    expect(body.content).toBe('nice post');
+  });
+
+  it('voting: upvote raises score, flip to downvote updates it, delete removes it', async () => {
+    const scoreOf = async () => {
+      const res = await app.request(`/forum/posts/${postId}`, {}, env);
+      const body = (await res.json()) as { post: { score: number } };
+      return body.post.score;
+    };
+
+    const baseline = await scoreOf();
+
+    let voteRes = await app.request(
+      '/forum/vote',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...authHeader(userB.accessToken) },
+        body: JSON.stringify({ votableType: 'post', votableId: postId, value: 1 }),
+      },
+      env,
+    );
+    expect(voteRes.status).toBe(200);
+    expect(await scoreOf()).toBe(baseline + 1);
+
+    // re-voting upserts rather than duplicating
+    voteRes = await app.request(
+      '/forum/vote',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...authHeader(userB.accessToken) },
+        body: JSON.stringify({ votableType: 'post', votableId: postId, value: -1 }),
+      },
+      env,
+    );
+    expect(voteRes.status).toBe(200);
+    expect(await scoreOf()).toBe(baseline - 1);
+
+    const unvoteRes = await app.request(
+      '/forum/vote',
+      {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json', ...authHeader(userB.accessToken) },
+        body: JSON.stringify({ votableType: 'post', votableId: postId }),
+      },
+      env,
+    );
+    expect(unvoteRes.status).toBe(200);
+    expect(await scoreOf()).toBe(baseline);
+  });
+
+  it('RLS: a user cannot insert a post attributed to a different profile_id', async () => {
+    const profileBRes = await app.request('/user/me', { headers: authHeader(userB.accessToken) }, env);
+    const profileB = (await profileBRes.json()) as { id: string };
+
+    const db = getDb(env as Bindings);
+    const claimsA = decodeJwt(userA.accessToken);
+    await expect(
+      withUser(db, claimsA, (tx) =>
+        tx.insert(posts).values({ profileId: profileB.id, title: 'x', content: 'y' }).returning(),
+      ),
+    ).rejects.toThrow();
+  });
+});

--- a/backend/test/integration/user.test.ts
+++ b/backend/test/integration/user.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { app } from '../../src/index';
+import { env, isDbReachable, signUp, authHeader } from './env';
+
+const dbUp = await isDbReachable();
+
+describe.skipIf(!dbUp)('user routes (integration, local Supabase)', () => {
+  it('GET /user/me returns 401 without a token', async () => {
+    const res = await app.request('/user/me', {}, env);
+    expect(res.status).toBe(401);
+  });
+
+  it('GET /user/me returns 200 with a profile object', async () => {
+    const { accessToken, username } = await signUp('userme');
+    const res = await app.request('/user/me', { headers: authHeader(accessToken) }, env);
+    expect(res.status).toBe(200);
+    const profile = (await res.json()) as { id: string; username: string; role: string };
+    expect(profile.id).toBeTruthy();
+    expect(profile.username).toBe(username);
+    expect(profile.role).toBe('user');
+  });
+});

--- a/backend/vitest.config.ts
+++ b/backend/vitest.config.ts
@@ -1,8 +1,12 @@
-import { defineConfig } from 'vitest/config';
+import { defineConfig, configDefaults } from 'vitest/config';
 
 export default defineConfig({
   test: {
     include: ['test/**/*.test.ts'],
+    // Integration tests hit a local Supabase stack and have their own runner
+    // (`bun run test:integration`, see vitest.integration.config.ts) — CI has no
+    // DB, so they must never run under the default `test` script.
+    exclude: [...configDefaults.exclude, 'test/integration/**'],
     environment: 'node',
     coverage: {
       provider: 'v8',

--- a/backend/vitest.integration.config.ts
+++ b/backend/vitest.integration.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+// Integration tests against a local Supabase stack — not run by `bun run test` /
+// CI (no DB there, no coverage thresholds here). See test/integration/env.ts for
+// how to run them: supabase start && bun run db:migrate && bun run test:integration
+export default defineConfig({
+  test: {
+    include: ['test/integration/**/*.test.ts'],
+    environment: 'node',
+  },
+});


### PR DESCRIPTION
## Summary
- Adds integration tests for the forum + user endpoints, run against a local Supabase stack (`supabase start` + `bun run db:migrate`).
- Covers: `GET /forum/posts` (default/new/top), `GET /forum/posts/:id` (200 + 404), `POST /forum/posts` (401 unauthed / 201 authed), `POST /forum/posts/:id/comments`, `POST`/`DELETE /forum/vote` (upvote, flip to downvote via upsert, unvote — score checked at each step), `GET /user/me` (401/200), and an RLS sanity check that a user can't insert a post with a foreign `profile_id`.
- New `bun run test:integration` script (`vitest run --config vitest.integration.config.ts`) targeting only `test/integration/**`. `vitest.config.ts` now excludes that folder so the default `bun run test` (used by CI, which has no Supabase) never touches these.
- Tests also `describe.skipIf` when `DATABASE_URL` isn't reachable, as a second safety net if `test:integration` is ever run without the stack up.

## Test plan
- [x] `supabase start` (local) + `bun run db:migrate`
- [x] `bun run test:integration` — 2 files, 10 passed
- [x] `bun run test` (default/CI script) — 5 files, 40 passed, 2 todo — unaffected
- [x] `bun run typecheck` / `bun run lint` / `bun run format:check` — clean
- [x] Confirmed `describe.skipIf` skips cleanly (exit 0) when Supabase is stopped

https://claude.ai/code/session_01VTrUkrhExrpTVr9vGFrY4E