### PR TITLE
feat(website): privacy policy page

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,2 +1,6 @@
 # Cloudflare's community forum 403s all bots/crawlers, so valid links there fail the check.
 community.cloudflare.com
+
+# Local dev URLs in README examples aren't reachable from CI.
+localhost
+127.0.0.1

--- a/website/app/privacy/page.tsx
+++ b/website/app/privacy/page.tsx
@@ -1,4 +1,3 @@
-import Link from 'next/link';
 import type { Metadata } from 'next';
 import { SectionContainer } from '../../components/ui/section-container';
 import { GraphPattern } from '../../components/effects/GraphPattern';
@@ -9,17 +8,25 @@ export const metadata: Metadata = {
   description: 'What data CCCSolutions collects, why, and the third-party services involved.',
 };
 
-const CONTACT_EMAIL = 'willi64645@gmail.com';
+const CONTACT_EMAIL = 'william@cccsolutions.ca';
 const EFFECTIVE_DATE = 'August 9, 2026';
 
 function Section({ title, children }: { title: string; children: React.ReactNode }) {
   return (
     <section className="mt-10 first:mt-0">
       <h2 className="text-xl font-semibold tracking-tight text-foreground">{title}</h2>
-      <div className="mt-3 space-y-3 text-sm md:text-base leading-relaxed text-foreground-light">
+      <div className="mt-3 space-y-3 text-sm leading-relaxed text-foreground-light md:text-base">
         {children}
       </div>
     </section>
+  );
+}
+
+function ExtLink({ href, children }: { href: string; children: React.ReactNode }) {
+  return (
+    <a href={href} target="_blank" rel="noopener noreferrer" className="text-brand hover:underline">
+      {children}
+    </a>
   );
 }
 
@@ -47,140 +54,122 @@ export default function PrivacyPage() {
           <GraphPattern className="h-full w-full text-white opacity-80" />
         </div>
 
-        <SectionContainer size="large" className="relative z-10 pt-16 pb-10">
-          <h1 className="text-4xl md:text-5xl font-semibold tracking-tight text-white">
+        <SectionContainer size="large" className="relative z-10 pb-10 pt-16">
+          <h1 className="text-4xl font-semibold tracking-tight text-white md:text-5xl">
             Privacy Policy
           </h1>
-          <p className="mt-4 text-base md:text-lg text-white/85 max-w-2xl">
-            CCCSolutions is a free, open-source, community-run archive. This page explains what data
-            the site collects, why, and which third-party services are involved.
-          </p>
-          <p className="mt-3 text-sm text-white/70">Last updated: {EFFECTIVE_DATE}</p>
+          <p className="mt-4 text-sm text-white/70">Last updated: {EFFECTIVE_DATE}</p>
         </SectionContainer>
       </div>
 
       <SectionContainer size="small" className="py-14">
         <Section title="Who we are">
           <p>
-            CCCSolutions is a volunteer, non-commercial project that publishes solutions to the
-            Canadian Computing Competition and hosts a community forum. We do not sell data or run
-            advertising. The site&apos;s source code is public on{' '}
-            <a
-              href="https://github.com/CCCSolutions/CCCSolutions"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-brand hover:underline"
-            >
-              GitHub
-            </a>
-            .
+            CCCSolutions is a volunteer, non-commercial project. We do not sell your data or run
+            ads, and the site&apos;s source code is public on{' '}
+            <ExtLink href="https://github.com/CCCSolutions/CCCSolutions">GitHub</ExtLink>.
           </p>
         </Section>
 
         <Section title="What we collect">
-          <p>We only collect what the site needs to function:</p>
           <ul className="list-disc space-y-2 pl-6">
             <li>
-              <span className="font-medium text-foreground">Account details.</span> When you sign
-              up, we store your email address and the username you choose. If you sign in with
-              Google, we also receive your name and profile picture from Google.
+              <span className="font-medium text-foreground">Account details:</span> your email
+              address and the username you choose. If you sign in with Google, we also receive your
+              name and profile picture.
             </li>
             <li>
-              <span className="font-medium text-foreground">Content you post.</span> The threads,
-              comments, and votes you create in the forum are stored and shown publicly next to your
-              username.
+              <span className="font-medium text-foreground">Content you post:</span> the threads,
+              comments, and votes you create, shown publicly next to your username.
             </li>
             <li>
-              <span className="font-medium text-foreground">Usage analytics.</span> We use Google
-              Analytics to understand aggregate traffic (pages visited, device and browser type,
-              approximate region from IP address). This is used in aggregate, not to identify you.
+              <span className="font-medium text-foreground">Usage analytics:</span> Google Analytics
+              records aggregate traffic such as pages visited, device and browser type, and
+              approximate region from your IP address.
             </li>
             <li>
-              <span className="font-medium text-foreground">Security signals.</span> Sign-up and
-              sign-in are protected by Cloudflare Turnstile, which processes a challenge token and
-              your IP address to tell humans from bots.
+              <span className="font-medium text-foreground">Security signals:</span> Cloudflare
+              Turnstile processes a challenge token and your IP address to block bots at sign-up and
+              sign-in.
             </li>
             <li>
-              <span className="font-medium text-foreground">Technical logs.</span> As with any
-              website, our host receives standard request data such as your IP address and browser
-              user-agent to serve pages and keep the site secure.
+              <span className="font-medium text-foreground">Technical logs:</span> our host receives
+              standard request data such as your IP address and browser user-agent.
             </li>
           </ul>
         </Section>
 
-        <Section title="Third-party services we rely on">
-          <p>Your data is handled by a small number of providers, each for a specific purpose:</p>
+        <Section title="Third-party services">
           <ul className="list-disc space-y-2 pl-6">
             <li>
-              <span className="font-medium text-foreground">Supabase</span> — authentication and the
-              database that stores your account and forum content.
+              <span className="font-medium text-foreground">Supabase:</span> authentication and the
+              database that stores your account and forum content.{' '}
+              <ExtLink href="https://supabase.com/privacy">Privacy policy</ExtLink>.
             </li>
             <li>
-              <span className="font-medium text-foreground">Google</span> — optional Google sign-in
-              (OAuth) and Google Analytics for usage statistics.
+              <span className="font-medium text-foreground">Google:</span> optional Google sign-in
+              and Google Analytics.{' '}
+              <ExtLink href="https://policies.google.com/privacy">Privacy policy</ExtLink>.
             </li>
             <li>
-              <span className="font-medium text-foreground">Cloudflare</span> — hosting and content
-              delivery, plus Turnstile bot protection.
+              <span className="font-medium text-foreground">Cloudflare:</span> hosting, content
+              delivery, and Turnstile bot protection.{' '}
+              <ExtLink href="https://www.cloudflare.com/en-ca/turnstile-privacy-policy/">
+                Turnstile privacy policy
+              </ExtLink>
+              .
             </li>
           </ul>
-          <p>
-            Each provider processes data under its own privacy policy. We share only what those
-            services need to do their job, and never sell your information.
-          </p>
         </Section>
 
-        <Section title="Cookies">
-          <p>
-            We use cookies for two things: keeping you signed in (a session cookie set by Supabase)
-            and Google Analytics (which sets its own analytics cookies). You can block or clear
-            cookies in your browser; blocking the session cookie will sign you out, and blocking
-            analytics cookies has no effect on using the site.
-          </p>
+        <Section title="Cookies we use">
+          <ul className="list-disc space-y-2 pl-6">
+            <li>
+              <span className="font-medium text-foreground">Essential cookies:</span> keep you
+              signed in. Blocking them signs you out.
+            </li>
+            <li>
+              <span className="font-medium text-foreground">Analytics cookies:</span> set by Google
+              Analytics. Blocking them does not affect using the site.
+            </li>
+          </ul>
         </Section>
 
-        <Section title="How long we keep it">
+        <Section title="Data retention">
           <p>
-            Your account and the content you post remain until you ask us to delete them. Analytics
-            data is retained according to Google&apos;s standard retention settings. If you delete
-            your account, your posts and comments may be retained in anonymized form to keep
-            existing discussions readable.
+            We keep your account and the content you post until you ask us to delete it. Google
+            Analytics data follows Google&apos;s default retention period.
           </p>
         </Section>
 
         <Section title="Your choices">
           <p>
-            You can edit your profile at any time, and you can request deletion of your account and
-            associated data by emailing us. To opt out of analytics, block analytics cookies in your
-            browser or use a tracker-blocking extension.
+            To delete your account and its data, email us. You can opt out of analytics by blocking
+            cookies in your browser.
           </p>
         </Section>
 
         <Section title="Children">
           <p>
-            CCCSolutions is aimed at students and educators. We do not knowingly collect more than
-            the account and forum information described above from anyone, and we ask that younger
-            students use the site with a parent or teacher&apos;s awareness.
+            CCCSolutions is used by students and educators. We only collect the account and forum
+            data described above. Younger students should use the site with a parent or
+            teacher&apos;s awareness.
           </p>
         </Section>
 
-        <Section title="Changes to this policy">
+        <Section title="Changes">
           <p>
-            We may update this policy as the site evolves. When we do, we&apos;ll change the
-            &quot;last updated&quot; date above. Material changes will be noted on the site.
+            We may update this policy as the site changes. The date above reflects the latest
+            version.
           </p>
         </Section>
 
         <Section title="Contact">
           <p>
-            Questions, or want your data removed? Email{' '}
+            Questions, or want your data deleted? Email{' '}
             <a href={`mailto:${CONTACT_EMAIL}`} className="text-brand hover:underline">
               {CONTACT_EMAIL}
             </a>
-            . You can also reach the project through{' '}
-            <Link href="/about" className="text-brand hover:underline">
-              the About page
-            </Link>
             .
           </p>
         </Section>

--- a/website/app/privacy/page.tsx
+++ b/website/app/privacy/page.tsx
@@ -119,46 +119,46 @@ export default function PrivacyPage() {
           </ul>
         </Section>
 
-        <Section title="Cookies we use">
+        <Section title="Cookies">
+          <p>The site uses a few cookies:</p>
           <ul className="list-disc space-y-2 pl-6">
             <li>
-              <span className="font-medium text-foreground">Essential cookies</span> to keep you
-              signed in.
+              <span className="font-medium text-foreground">Essential:</span> Cloudflare sets a
+              clearance cookie so its bot protection works and you can reach the site.
             </li>
             <li>
-              <span className="font-medium text-foreground">Analytics cookies</span> from Google
-              Analytics, so we can see how the site is used.
+              <span className="font-medium text-foreground">Analytics:</span> Google Analytics and
+              Cloudflare Insights set cookies that show us how the site is used.
             </li>
           </ul>
         </Section>
 
         <Section title="Data retention">
           <p>
-            We keep your account and the posts you make for as long as your account exists. Ask us
-            to delete them and we will. Analytics data is held by Google under its own retention
-            settings.
+            We keep your account and your posts for as long as your account is active, or until you
+            ask us to remove them. Analytics data stays with Google and Cloudflare under their own
+            retention periods.
           </p>
         </Section>
 
         <Section title="Your choices">
           <p>
-            Want to see or remove your data? Just email us and we&apos;ll take care of it. You can
-            also opt out of analytics by blocking cookies in your browser.
+            You can ask to see or delete your data any time by emailing us. To opt out of analytics,
+            block cookies in your browser.
           </p>
         </Section>
 
         <Section title="Children">
           <p>
-            CCCSolutions is built for students and teachers. We only collect the account and forum
-            details covered above, and if you&apos;re a younger student, we&apos;d suggest using the
-            site with a parent or teacher.
+            CCCSolutions is built for students and teachers, and we only collect the account and
+            forum details described above. If you&apos;re a younger student, we&apos;d recommend
+            using the site with a parent or teacher.
           </p>
         </Section>
 
         <Section title="Changes">
           <p>
-            We&apos;ll update this page if things change, and the date at the top always shows the
-            latest version.
+            If we change how we handle data, we&apos;ll update this page and the date at the top.
           </p>
         </Section>
 

--- a/website/app/privacy/page.tsx
+++ b/website/app/privacy/page.tsx
@@ -122,48 +122,49 @@ export default function PrivacyPage() {
         <Section title="Cookies we use">
           <ul className="list-disc space-y-2 pl-6">
             <li>
-              <span className="font-medium text-foreground">Essential cookies:</span> keep you
-              signed in. Blocking them signs you out.
+              <span className="font-medium text-foreground">Essential cookies</span> to keep you
+              signed in.
             </li>
             <li>
-              <span className="font-medium text-foreground">Analytics cookies:</span> set by Google
-              Analytics. Blocking them does not affect using the site.
+              <span className="font-medium text-foreground">Analytics cookies</span> from Google
+              Analytics, so we can see how the site is used.
             </li>
           </ul>
         </Section>
 
         <Section title="Data retention">
           <p>
-            We keep your account and the content you post until you ask us to delete it. Google
-            Analytics data follows Google&apos;s default retention period.
+            We keep your account and the posts you make for as long as your account exists. Ask us
+            to delete them and we will. Analytics data is held by Google under its own retention
+            settings.
           </p>
         </Section>
 
         <Section title="Your choices">
           <p>
-            To delete your account and its data, email us. You can opt out of analytics by blocking
-            cookies in your browser.
+            Want to see or remove your data? Just email us and we&apos;ll take care of it. You can
+            also opt out of analytics by blocking cookies in your browser.
           </p>
         </Section>
 
         <Section title="Children">
           <p>
-            CCCSolutions is used by students and educators. We only collect the account and forum
-            data described above. Younger students should use the site with a parent or
-            teacher&apos;s awareness.
+            CCCSolutions is built for students and teachers. We only collect the account and forum
+            details covered above, and if you&apos;re a younger student, we&apos;d suggest using the
+            site with a parent or teacher.
           </p>
         </Section>
 
         <Section title="Changes">
           <p>
-            We may update this policy as the site changes. The date above reflects the latest
-            version.
+            We&apos;ll update this page if things change, and the date at the top always shows the
+            latest version.
           </p>
         </Section>
 
         <Section title="Contact">
           <p>
-            Questions, or want your data deleted? Email{' '}
+            Questions about any of this? Email{' '}
             <a href={`mailto:${CONTACT_EMAIL}`} className="text-brand hover:underline">
               {CONTACT_EMAIL}
             </a>

--- a/website/app/privacy/page.tsx
+++ b/website/app/privacy/page.tsx
@@ -1,0 +1,190 @@
+import Link from 'next/link';
+import type { Metadata } from 'next';
+import { SectionContainer } from '../../components/ui/section-container';
+import { GraphPattern } from '../../components/effects/GraphPattern';
+import { NoiseTexture } from '../../components/effects/NoiseTexture';
+
+export const metadata: Metadata = {
+  title: 'Privacy Policy',
+  description: 'What data CCCSolutions collects, why, and the third-party services involved.',
+};
+
+const CONTACT_EMAIL = 'willi64645@gmail.com';
+const EFFECTIVE_DATE = 'August 9, 2026';
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="mt-10 first:mt-0">
+      <h2 className="text-xl font-semibold tracking-tight text-foreground">{title}</h2>
+      <div className="mt-3 space-y-3 text-sm md:text-base leading-relaxed text-foreground-light">
+        {children}
+      </div>
+    </section>
+  );
+}
+
+export default function PrivacyPage() {
+  return (
+    <div className="bg-background text-foreground">
+      <div
+        data-theme="dark"
+        className="relative overflow-hidden border-b border-border-default text-white"
+        style={{ backgroundColor: 'hsl(239 58% 45%)' }}
+      >
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-0"
+          style={{
+            background:
+              'radial-gradient(150% 140% at 50% -45%, hsl(239 70% 70% / 0.25), transparent 90%)',
+          }}
+        />
+        <NoiseTexture opacity={0.26} />
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-y-0 right-0 w-full sm:w-3/4 lg:w-3/5"
+        >
+          <GraphPattern className="h-full w-full text-white opacity-80" />
+        </div>
+
+        <SectionContainer size="large" className="relative z-10 pt-16 pb-10">
+          <h1 className="text-4xl md:text-5xl font-semibold tracking-tight text-white">
+            Privacy Policy
+          </h1>
+          <p className="mt-4 text-base md:text-lg text-white/85 max-w-2xl">
+            CCCSolutions is a free, open-source, community-run archive. This page explains what data
+            the site collects, why, and which third-party services are involved.
+          </p>
+          <p className="mt-3 text-sm text-white/70">Last updated: {EFFECTIVE_DATE}</p>
+        </SectionContainer>
+      </div>
+
+      <SectionContainer size="small" className="py-14">
+        <Section title="Who we are">
+          <p>
+            CCCSolutions is a volunteer, non-commercial project that publishes solutions to the
+            Canadian Computing Competition and hosts a community forum. We do not sell data or run
+            advertising. The site&apos;s source code is public on{' '}
+            <a
+              href="https://github.com/CCCSolutions/CCCSolutions"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-brand hover:underline"
+            >
+              GitHub
+            </a>
+            .
+          </p>
+        </Section>
+
+        <Section title="What we collect">
+          <p>We only collect what the site needs to function:</p>
+          <ul className="list-disc space-y-2 pl-6">
+            <li>
+              <span className="font-medium text-foreground">Account details.</span> When you sign
+              up, we store your email address and the username you choose. If you sign in with
+              Google, we also receive your name and profile picture from Google.
+            </li>
+            <li>
+              <span className="font-medium text-foreground">Content you post.</span> The threads,
+              comments, and votes you create in the forum are stored and shown publicly next to your
+              username.
+            </li>
+            <li>
+              <span className="font-medium text-foreground">Usage analytics.</span> We use Google
+              Analytics to understand aggregate traffic (pages visited, device and browser type,
+              approximate region from IP address). This is used in aggregate, not to identify you.
+            </li>
+            <li>
+              <span className="font-medium text-foreground">Security signals.</span> Sign-up and
+              sign-in are protected by Cloudflare Turnstile, which processes a challenge token and
+              your IP address to tell humans from bots.
+            </li>
+            <li>
+              <span className="font-medium text-foreground">Technical logs.</span> As with any
+              website, our host receives standard request data such as your IP address and browser
+              user-agent to serve pages and keep the site secure.
+            </li>
+          </ul>
+        </Section>
+
+        <Section title="Third-party services we rely on">
+          <p>Your data is handled by a small number of providers, each for a specific purpose:</p>
+          <ul className="list-disc space-y-2 pl-6">
+            <li>
+              <span className="font-medium text-foreground">Supabase</span> — authentication and the
+              database that stores your account and forum content.
+            </li>
+            <li>
+              <span className="font-medium text-foreground">Google</span> — optional Google sign-in
+              (OAuth) and Google Analytics for usage statistics.
+            </li>
+            <li>
+              <span className="font-medium text-foreground">Cloudflare</span> — hosting and content
+              delivery, plus Turnstile bot protection.
+            </li>
+          </ul>
+          <p>
+            Each provider processes data under its own privacy policy. We share only what those
+            services need to do their job, and never sell your information.
+          </p>
+        </Section>
+
+        <Section title="Cookies">
+          <p>
+            We use cookies for two things: keeping you signed in (a session cookie set by Supabase)
+            and Google Analytics (which sets its own analytics cookies). You can block or clear
+            cookies in your browser; blocking the session cookie will sign you out, and blocking
+            analytics cookies has no effect on using the site.
+          </p>
+        </Section>
+
+        <Section title="How long we keep it">
+          <p>
+            Your account and the content you post remain until you ask us to delete them. Analytics
+            data is retained according to Google&apos;s standard retention settings. If you delete
+            your account, your posts and comments may be retained in anonymized form to keep
+            existing discussions readable.
+          </p>
+        </Section>
+
+        <Section title="Your choices">
+          <p>
+            You can edit your profile at any time, and you can request deletion of your account and
+            associated data by emailing us. To opt out of analytics, block analytics cookies in your
+            browser or use a tracker-blocking extension.
+          </p>
+        </Section>
+
+        <Section title="Children">
+          <p>
+            CCCSolutions is aimed at students and educators. We do not knowingly collect more than
+            the account and forum information described above from anyone, and we ask that younger
+            students use the site with a parent or teacher&apos;s awareness.
+          </p>
+        </Section>
+
+        <Section title="Changes to this policy">
+          <p>
+            We may update this policy as the site evolves. When we do, we&apos;ll change the
+            &quot;last updated&quot; date above. Material changes will be noted on the site.
+          </p>
+        </Section>
+
+        <Section title="Contact">
+          <p>
+            Questions, or want your data removed? Email{' '}
+            <a href={`mailto:${CONTACT_EMAIL}`} className="text-brand hover:underline">
+              {CONTACT_EMAIL}
+            </a>
+            . You can also reach the project through{' '}
+            <Link href="/about" className="text-brand hover:underline">
+              the About page
+            </Link>
+            .
+          </p>
+        </Section>
+      </SectionContainer>
+    </div>
+  );
+}

--- a/website/app/privacy/page.tsx
+++ b/website/app/privacy/page.tsx
@@ -114,10 +114,7 @@ export default function PrivacyPage() {
             <li>
               <span className="font-medium text-foreground">Cloudflare:</span> hosting, content
               delivery, and Turnstile bot protection.{' '}
-              <ExtLink href="https://www.cloudflare.com/en-ca/turnstile-privacy-policy/">
-                Turnstile privacy policy
-              </ExtLink>
-              .
+              <ExtLink href="https://www.cloudflare.com/privacypolicy/">Privacy policy</ExtLink>.
             </li>
           </ul>
         </Section>

--- a/website/components/layout/Footer.tsx
+++ b/website/components/layout/Footer.tsx
@@ -59,6 +59,11 @@ const Footer = () => {
                 </a>
               </li>
               <li>
+                <Link href="/privacy" className="hover:text-foreground hover:underline">
+                  Privacy
+                </Link>
+              </li>
+              <li>
                 <a
                   href="mailto:willi64645@gmail.com"
                   className="hover:text-foreground hover:underline"


### PR DESCRIPTION
## Description

Adds a public Privacy Policy at `/privacy`. Google requires a hosted privacy policy on the verified domain before it will verify our OAuth consent screen (which is what makes the Google sign-in prompt show "CCCSolutions" instead of the raw `*.supabase.co` host). The content is written from what the app actually does, not boilerplate.

## Changes

- New `app/privacy/page.tsx`: discloses account data (email, username, and name/avatar via Google sign-in), forum content (posts/comments/votes, public), Google Analytics, Cloudflare Turnstile + hosting, cookies, retention, user choices, and a contact address. Matches the About page's hero + section style.
- Footer: adds a "Privacy" link in the Project column.
- Contact email and effective date are top-of-file constants (`CONTACT_EMAIL`, `EFFECTIVE_DATE`) so they're trivial to change.

## Testing

- `tsc --noEmit`, `next lint`, and `prettier --check` all pass.
- Static content page; no data flow or API changes.

## Linked issues

None.

## Checklist

- [x] I read CONTRIBUTING.md and gave my own code a once-over (it runs and does what the PR says)
- [x] `tsc`, lint, and tests pass locally (CI checks these too)
- [ ] New backend feature code (`backend/src/`) has vitest tests — n/a, frontend page
- [x] Code is formatted and matches the surrounding style (CI checks this)
- [x] Docs/comments updated if behavior or APIs changed
