### PR TITLE
fix(website): display_name at signup + footer contact email

### DIFF
--- a/website/components/auth/AuthForm.tsx
+++ b/website/components/auth/AuthForm.tsx
@@ -99,7 +99,7 @@ export default function AuthForm({ mode }: { mode: Mode }) {
           email,
           password,
           options: {
-            data: { username },
+            data: { username, display_name: username },
             ...(captchaToken ? { captchaToken } : {}),
           },
         });

--- a/website/components/layout/Footer.tsx
+++ b/website/components/layout/Footer.tsx
@@ -65,7 +65,7 @@ const Footer = () => {
               </li>
               <li>
                 <a
-                  href="mailto:willi64645@gmail.com"
+                  href="mailto:william@cccsolutions.ca"
                   className="hover:text-foreground hover:underline"
                 >
                   Contact

--- a/website/components/layout/Navbar.tsx
+++ b/website/components/layout/Navbar.tsx
@@ -41,7 +41,7 @@ const Navbar = () => {
             <Link href="/" className="flex items-center">
               <Image
                 src="/images/mmhs_logo_transparent.png"
-                alt="MMHS Logo"
+                alt="CCCSolutions"
                 width={40}
                 height={40}
                 className="h-10 w-auto"


### PR DESCRIPTION
## Description

Two small auth/contact fixes surfaced while prepping the Google OAuth flow.

## Changes

- Signup now sets `display_name` (to the username) in `raw_user_meta_data`, so the Supabase dashboard shows the username instead of a blank display name. `username` is still passed for profile creation.
- Footer contact link uses `william@cccsolutions.ca` instead of the old personal Gmail.

## Testing

- `tsc --noEmit` passes. No behavior change beyond the metadata field and the mailto target.

## Linked issues

None.

## Checklist

- [x] I read CONTRIBUTING.md and gave my own code a once-over (it runs and does what the PR says)
- [x] `tsc`, lint, and tests pass locally (CI checks these too)
- [ ] New backend feature code (`backend/src/`) has vitest tests — n/a, frontend only
- [x] Code is formatted and matches the surrounding style (CI checks this)
- [x] Docs/comments updated if behavior or APIs changed
