### PR TITLE
fix(backend): forum cache — short TTL + purge on writes

### DIFF
--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -14,6 +14,26 @@ There is no in-Worker Cloudflare Access validation. A Worker has no origin IP, s
 - The public custom domains (`api.cccsolutions.ca`, `v2.cccsolutions.ca`) are intentionally public, protected by **WAF rate-limiting rules** (per-IP ceilings).
 - Anything needing real auth (admin R2 upload, user accounts) uses app-level auth — an admin secret via `wrangler secret`, or Supabase RLS — never Cloudflare Access JWTs.
 
+## RULE: Workers Cache is ON — every route must decide its cacheability
+
+`wrangler.jsonc` enables Workers Cache, a per-Worker edge cache driven **only** by
+the `Cache-Control` headers we set (no zone Cache Rule or cache-level applies). The
+trap: **a response with no `Cache-Control` is still cached**, using an RFC 9111
+heuristic TTL — that is how the forum list silently went stale for over an hour.
+
+So every GET must decide, explicitly:
+
+- **Opt in:** set `Cache-Control` + a `Cache-Tag`, AND purge that tag on every write
+  that changes what it returns (see the R2 rule below, and `purgeForum()` in
+  `src/forum/routes.ts`). No purge, no cache.
+- **Opt out:** set `Cache-Control: no-store`. **Per-user responses MUST be `no-store`**
+  — a shared cache would serve one user's data to another. (This is why the future
+  `GET /forum/votes/mine` must be `no-store`.)
+
+Forum reads are tagged `forum-posts`; every forum write purges it. Any new
+forum-mutating route (post/comment edit or delete, moderation, a profile edit that
+changes the `author` fields) MUST purge `forum-posts` too.
+
 ## RULE: every R2 write MUST purge the contest cache tag
 
 `/list` and `/preview` are served with `Cache-Tag: contest:<year>:<code>` and an
@@ -41,4 +61,5 @@ App data (forum, users) lives in **Supabase Postgres**, accessed with **Drizzle 
 - **RLS is currently inert.** The Worker connects as a privileged pooler role, so `auth.uid()` is NULL and `pgPolicy` rules are bypassed — authorization is enforced in the API layer. Defined policies are defense-in-depth until we set `request.jwt.claims` per request (planned; see `../docs/Roadmap40.md`).
 
 ## Migration / deploy notes
+
 Wrangler hardening, R2 serving pattern, and the Pages migration plan live in the repo-root `DEPLOYMENT_NOTES.local.md` (gitignored).

--- a/backend/src/forum/routes.ts
+++ b/backend/src/forum/routes.ts
@@ -1,4 +1,4 @@
-import { Hono } from 'hono';
+import { Hono, type Context } from 'hono';
 import { and, desc, eq, sql } from 'drizzle-orm';
 import type { Bindings } from '../types';
 import { getDb, withUser } from '../db';
@@ -10,6 +10,20 @@ const forum = new Hono<{ Bindings: Bindings; Variables: AuthVars }>();
 
 const postScore = sql<number>`coalesce((select sum(${votes.value})::int from ${votes} where ${votes.votableType} = 'post' and ${votes.votableId} = ${posts.id}), 0)`;
 const commentScore = sql<number>`coalesce((select sum(${votes.value})::int from ${votes} where ${votes.votableType} = 'comment' and ${votes.votableId} = ${comments.id}), 0)`;
+
+// Workers Cache is on (wrangler.jsonc): a response with NO Cache-Control is still
+// cached (RFC 9111 heuristic TTL). Reads opt into a short TTL under one tag and every
+// write purges it, so posts/comments/votes show up at once, not after the TTL.
+// REMINDER: any new forum-mutating route MUST call purgeForum(c). And a per-user read
+// (e.g. a future GET /votes/mine for the upvote fix) MUST set Cache-Control: no-store —
+// never cache per-user data behind a shared cache. See the cache rule in AGENTS.md.
+const FORUM_CACHE = 'public, max-age=30, stale-while-revalidate=600';
+
+function purgeForum(c: Context<{ Bindings: Bindings; Variables: AuthVars }>): void {
+  const ctx = c.executionCtx as unknown as ExecutionContext;
+  if (!ctx.cache) return;
+  ctx.waitUntil(ctx.cache.purge({ tags: ['forum-posts'] }));
+}
 
 forum.get('/posts', async (c) => {
   const sort = c.req.query('sort') === 'top' ? 'top' : 'new';
@@ -27,6 +41,8 @@ forum.get('/posts', async (c) => {
     .leftJoin(profiles, eq(profiles.id, posts.profileId))
     .orderBy(sort === 'top' ? desc(postScore) : desc(posts.createdAt))
     .limit(20);
+  c.header('Cache-Control', FORUM_CACHE);
+  c.header('Cache-Tag', 'forum-posts');
   return c.json(res);
 });
 
@@ -46,7 +62,10 @@ forum.get('/posts/:id', async (c) => {
     .leftJoin(profiles, eq(profiles.id, posts.profileId))
     .where(eq(posts.id, id))
     .limit(1);
-  if (!post) return c.json({ error: 'Post not found' }, 404);
+  if (!post) {
+    c.header('Cache-Control', 'no-store');
+    return c.json({ error: 'Post not found' }, 404);
+  }
 
   const thread = await db
     .select({
@@ -60,6 +79,8 @@ forum.get('/posts/:id', async (c) => {
     .leftJoin(profiles, eq(profiles.id, comments.profileId))
     .where(eq(comments.postId, id))
     .orderBy(desc(comments.createdAt));
+  c.header('Cache-Control', FORUM_CACHE);
+  c.header('Cache-Tag', 'forum-posts');
   return c.json({ post, comments: thread });
 });
 
@@ -73,6 +94,7 @@ forum.post('/posts', requireAuth, async (c) => {
       .values({ profileId: profile.id, ...parsed.data })
       .returning(),
   );
+  purgeForum(c);
   return c.json(post, 201);
 });
 
@@ -86,6 +108,7 @@ forum.post('/posts/:id/comments', requireAuth, async (c) => {
       .values({ postId: c.req.param('id')!, profileId: profile.id, content: parsed.data.content })
       .returning(),
   );
+  purgeForum(c);
   return c.json(comment, 201);
 });
 
@@ -100,6 +123,7 @@ forum.post('/vote', requireAuth, async (c) => {
       .values({ profileId: profile.id, votableType, votableId, value })
       .onConflictDoUpdate({ target: [votes.profileId, votes.votableType, votes.votableId], set: { value } }),
   );
+  purgeForum(c);
   return c.json({ ok: true });
 });
 
@@ -113,6 +137,7 @@ forum.delete('/vote', requireAuth, async (c) => {
       .delete(votes)
       .where(and(eq(votes.profileId, profile.id), eq(votes.votableType, votableType), eq(votes.votableId, votableId))),
   );
+  purgeForum(c);
   return c.json({ ok: true });
 });
 


### PR DESCRIPTION
## Description

The forum list was serving a stale copy for over an hour (`cf-cache-status: HIT`, `age: 4055`+), so newly created posts and votes stayed invisible on the forum home page.

Root cause: **Workers Cache is enabled** (`wrangler.jsonc`), and per RFC 9111 a response with **no `Cache-Control` header is still cacheable** via a heuristic TTL. The forum reads returned `c.json(...)` with no cache header, so Workers Cache stored them and picked its own (long) TTL. Nothing invalidated it on writes. Zone cache rules / cache-level are irrelevant here — Workers Cache only obeys the response headers we set.

Fix (mirrors the existing R2 `Cache-Tag` + purge pattern): forum reads opt into a **short** TTL under one tag, and **every forum write purges that tag**, so updates appear immediately and a missed purge self-heals in 30s instead of ~an hour.

## Changes

- `GET /forum/posts` and `GET /forum/posts/:id`: `Cache-Control: public, max-age=30, stale-while-revalidate=600` + `Cache-Tag: forum-posts`. The `:id` 404 sets `no-store` (don't cache a miss).
- `purgeForum(c)` helper; `POST /posts`, `POST /posts/:id/comments`, `POST /vote`, `DELETE /vote` all purge `forum-posts` via `waitUntil`.
- `backend/AGENTS.md`: new **"Workers Cache is ON"** rule — no header still caches, per-user responses MUST be `no-store`, and any forum-mutating route MUST purge `forum-posts`. Plus reminder comments in `forum/routes.ts` for the future `GET /forum/votes/mine` (upvote fix) so it's born `no-store`.

Scope: caching only — no upvote/vote-persistence changes (those are a separate PR).

## Testing

- `tsc --noEmit`, `eslint`, `prettier --check` all pass. CI runs the forum integration tests.
- **Post-merge one-time step:** purge the Cloudflare cache (or the `/forum/posts` URL) once to clear the entry that's already stale; after that the short TTL + purge-on-write keeps it fresh.

## Linked issues

None.

## Checklist

- [x] I read CONTRIBUTING.md and gave my own code a once-over (it runs and does what the PR says)
- [x] `tsc`, lint, and tests pass locally (CI checks these too)
- [ ] New backend feature code (`backend/src/`) has vitest tests — n/a, caching headers/purge on existing routes
- [x] Code is formatted and matches the surrounding style (CI checks this)
- [x] Docs/comments updated if behavior or APIs changed
