### PR TITLE
feat(forum): paginate the posts list (offset + Load more)

### DIFF
--- a/backend/src/forum/routes.ts
+++ b/backend/src/forum/routes.ts
@@ -25,8 +25,11 @@ function purgeForum(c: Context<{ Bindings: Bindings; Variables: AuthVars }>): vo
   ctx.waitUntil(ctx.cache.purge({ tags: ['forum-posts'] }));
 }
 
+const PAGE_SIZE = 20;
+
 forum.get('/posts', async (c) => {
   const sort = c.req.query('sort') === 'top' ? 'top' : 'new';
+  const offset = Math.max(0, Number.parseInt(c.req.query('offset') ?? '0', 10) || 0);
   const db = getDb(c.env);
   const res = await db
     .select({
@@ -40,7 +43,8 @@ forum.get('/posts', async (c) => {
     .from(posts)
     .leftJoin(profiles, eq(profiles.id, posts.profileId))
     .orderBy(sort === 'top' ? desc(postScore) : desc(posts.createdAt))
-    .limit(20);
+    .limit(PAGE_SIZE)
+    .offset(offset);
   c.header('Cache-Control', FORUM_CACHE);
   c.header('Cache-Tag', 'forum-posts');
   return c.json(res);

--- a/website/app/forum/page.tsx
+++ b/website/app/forum/page.tsx
@@ -28,33 +28,44 @@ type PostRow = {
 // Tracks the current user's vote on each post so the arrows reflect their state.
 type VoteMap = Record<string, 1 | -1 | 0>;
 
+const PAGE_SIZE = 20;
+
 export default function ForumPage() {
   const [posts, setPosts] = useState<PostRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [sortBy, setSortBy] = useState<'new' | 'top'>('new');
   const [voteMap, setVoteMap] = useState<VoteMap>({});
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [hasMore, setHasMore] = useState(false);
 
   const { state, profile, logout } = useAuth();
   const session = state === 'in';
   const { push } = useRouter();
 
-  const fetchPosts = useCallback(async () => {
-    try {
-      setLoading(true);
-      const res = await apiFetch(`/forum/posts?sort=${sortBy}`);
-      if (!res.ok) throw new Error(`Failed to load posts (${res.status})`);
-      const data = (await res.json()) as PostRow[];
-      setPosts(data);
-    } catch (error) {
-      console.error('Error fetching posts:', error);
-      toast.error('Could not load posts.');
-    } finally {
-      setLoading(false);
-    }
-  }, [sortBy]);
+  const fetchPosts = useCallback(
+    async (offset = 0) => {
+      const append = offset > 0;
+      try {
+        if (append) setLoadingMore(true);
+        else setLoading(true);
+        const res = await apiFetch(`/forum/posts?sort=${sortBy}&offset=${offset}`);
+        if (!res.ok) throw new Error(`Failed to load posts (${res.status})`);
+        const data = (await res.json()) as PostRow[];
+        setPosts((prev) => (append ? [...prev, ...data] : data));
+        setHasMore(data.length === PAGE_SIZE);
+      } catch (error) {
+        console.error('Error fetching posts:', error);
+        toast.error('Could not load posts.');
+      } finally {
+        if (append) setLoadingMore(false);
+        else setLoading(false);
+      }
+    },
+    [sortBy]
+  );
 
   useEffect(() => {
-    fetchPosts();
+    fetchPosts(0);
   }, [fetchPosts]);
 
   const handleVote = async (postId: string, value: 1 | -1) => {
@@ -241,6 +252,18 @@ export default function ForumPage() {
                 </Card>
               );
             })}
+          </div>
+        )}
+        {hasMore && !loading && (
+          <div className="mt-6 flex justify-center">
+            <Button
+              type="default"
+              size="small"
+              onClick={() => fetchPosts(posts.length)}
+              disabled={loadingMore}
+            >
+              {loadingMore ? 'Loading…' : 'Load more'}
+            </Button>
           </div>
         )}
       </SectionContainer>


### PR DESCRIPTION
## Description

The forum list hardcoded `.limit(20)` with no pagination, so only the 20 newest (or top) posts were ever reachable — everything older was invisible. Adds offset pagination + a "Load more" button. Addresses the intent of #106 (offset for now; cursor-based can come later, and is trickier for the `top` sort since it orders by a computed score).

## Changes

- **Backend** `GET /forum/posts`: optional `?offset` (default 0, clamped ≥ 0), returns `PAGE_SIZE = 20` per page via `.limit().offset()`. Caching (merged in #207) is unchanged — each offset is a distinct URL cached under the `forum-posts` tag and purged on any write.
- **Frontend** `/forum`: offset-aware `fetchPosts`, a **Load more** button that appends the next page (`hasMore` = the last page came back full), and a sort change resets to page 0.

Scope: the **posts list** only. The post-detail **comments** query is still unbounded (no cap) — a separate follow-up if we want to paginate those.

## Testing

- Backend + frontend `tsc`, lint, `prettier --check` all pass.
- Manual: with >20 posts, the list shows "Load more"; clicking appends the next 20; toggling New/Top resets to the first page.

## Linked issues

Refs #106.

## Checklist

- [x] I read CONTRIBUTING.md and gave my own code a once-over (it runs and does what the PR says)
- [x] `tsc`, lint, and tests pass locally (CI checks these too)
- [ ] New backend feature code (`backend/src/`) has vitest tests — offset is exercised by the existing `GET /forum/posts` tests; happy to add an explicit page test if you want
- [x] Code is formatted and matches the surrounding style (CI checks this)
- [x] Docs/comments updated if behavior or APIs changed
