### PR TITLE
perf(website): trim Google Fonts faces + defer gtag

### DIFF
--- a/website/app/layout.tsx
+++ b/website/app/layout.tsx
@@ -47,7 +47,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
         <link
-          href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@300;400;500;600;700&family=Poppins:wght@400;500;600;700&family=Roboto:ital,wght@0,100;0,300;0,400;0,500;0,700;0,900;1,100;1,300;1,400;1,500;1,700;1,900&family=Lato:ital,wght@0,100;0,300;0,400;0,700;0,900;1,100;1,300;1,400;1,700;1,900&family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap"
+          href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&family=Roboto:wght@400;500;700&family=Lato:wght@400;700&display=swap"
           rel="stylesheet"
         />
 
@@ -149,9 +149,13 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         />
       </head>
       <body className="bg-background">
-        <Script async src="https://www.googletagmanager.com/gtag/js?id=G-LD181T6802" />
+        <Script
+          strategy="afterInteractive"
+          src="https://www.googletagmanager.com/gtag/js?id=G-LD181T6802"
+        />
         <Script
           id="google-analytics"
+          strategy="afterInteractive"
           dangerouslySetInnerHTML={{
             __html: `
               window.dataLayer = window.dataLayer || [];


### PR DESCRIPTION
## Description

Safe, build-free web-perf wins for the homepage. Measured on prod: TTFB ~893ms, LCP 2.98s (LCP element is the hero `<h1>`), with a large FCP-to-LCP gap driven by render-blocking Google Fonts loaded via `<link>` to `fonts.googleapis.com` (roughly 160 font faces across five families). Total JS/CSS assets are only ~173KB, so this is not a bundle problem — it is font and third-party script loading.

This PR cuts the render-blocking font payload and makes Google Analytics explicitly non-blocking, without touching rendering modes, hosting, or `next/font`.

## Changes

- **Trim the Google Fonts `<link>` in `website/app/layout.tsx`:**
  - Removed **Poppins** and **Montserrat** entirely — grep across `website/` found them referenced only inside the font URL, never in any component, class, or CSS (`--font-sans` is `'DM Sans', 'Lato', 'Roboto', 'Arial', sans-serif`). Montserrat was loading the full `100..900` range in both roman and italic, so this is the single biggest reduction in faces.
  - **DM Sans** trimmed from `300;400;500;600;700` to `400;500;600;700`. The only Tailwind font-weight classes used in the app are `font-normal` (400), `font-medium` (500), `font-semibold` (600), and `font-bold` (700); there is no `font-light` and no explicit `font-weight` in CSS, so weight 300 was unused.
  - **Roboto** and **Lato** are only fallbacks in the CSS font stack. Reduced them to the roman weights the app actually uses (Roboto `400;500;700`, Lato `400;700`) and dropped all italic faces. Italics are safe to drop because the primary font (DM Sans) has no italic face loaded, so `italic` utilities are already synthesized by the browser.
  - `&display=swap` is preserved.
  - `<link rel="preconnect">` for `fonts.googleapis.com` and `fonts.gstatic.com` were already present and correct — kept as-is.
- **Google Analytics loading (`website/app/layout.tsx`):** set explicit `strategy="afterInteractive"` on both `next/script` gtag tags so analytics never render-blocks. The previously-measured `<link rel="preload">` for gtag no longer exists in the current `main` (gtag already loads via `next/script`); this change makes the deferred strategy explicit rather than relying on the `next/script` default.

## Testing

- `bun run typecheck` — passes.
- `bun run lint` — passes (the pre-existing `no-page-custom-font` warning is unchanged and relates to the deferred `next/font` migration below).
- `bunx prettier --write app/layout.tsx` — no changes needed.
- No `next build` / `next dev` run (per machine constraints); every change here is verifiable without a production build.

## Recommended follow-ups (not done)

Deliberately deferred as too risky to do unattended:

- **Switch to `next/font`** for self-hosted, optimally-subset fonts (would eliminate the render-blocking cross-origin request and the `no-page-custom-font` lint warning). Skipped due to the historical PostCSS/build hang on this machine.
- **Move `getGithubStars()` off the SSR critical path** in `website/app/page.tsx` (or change the homepage rendering mode) to reduce TTFB. Not touched.
- **Cloudflare / edge-cache / hosting changes** (e.g. cache headers for the font stylesheet, edge caching) — out of scope for a code PR.
- **Consider dropping Roboto/Lato from the webfont load entirely** and relying on locally-installed copies, since they are fallback-only. Left in (trimmed) to keep the visual fallback chain intact.

## Linked issues

Resolves #

## Checklist

- [x] I read CONTRIBUTING.md and gave my own code a once-over (it runs and does what the PR says)
- [x] `tsc`, lint, and tests pass locally (CI checks these too)
- [ ] New backend feature code (`backend/src/`) has vitest tests
- [x] Code is formatted and matches the surrounding style (CI checks this)
- [ ] Docs/comments updated if behavior or APIs changed
