### PR TITLE
feat(backend): ping Discord on forum writes + daily digest cron

### DIFF
--- a/backend/.dev.vars.example
+++ b/backend/.dev.vars.example
@@ -33,3 +33,11 @@ DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:54322/postgres
 # Supabase API URL, used to verify auth JWTs. Prod value is in wrangler.jsonc;
 # set the local stack here.
 SUPABASE_URL=http://127.0.0.1:54321
+
+# ---------------------------------------------------------------------------
+# Discord
+# ---------------------------------------------------------------------------
+# Webhook posted to on every forum write. In prod it's a Worker secret
+# (`wrangler secret put DISCORD_WEBHOOK_URL`). Leave EMPTY locally unless you
+# want `wrangler dev` writes pinging the real channel — unset disables sending.
+DISCORD_WEBHOOK_URL=

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -51,6 +51,24 @@ c.executionCtx.waitUntil(c.executionCtx.cache.purge({ tags: [`contest:${year}:${
 The admin router (`src/admin/routes.ts`) does this in `purgeContest()`. New write
 paths must call the same helper (or an equivalent purge). No purge, no merge.
 
+## RULE: every forum write MUST notify Discord
+
+Forum activity is announced to a Discord webhook (`src/notify.ts`), because nobody
+watches the site all day. **Any new forum-mutating route must call `notify(c, ...)`
+alongside `purgeForum(c)`** — the two live together in `src/forum/routes.ts`.
+
+Two constraints that are not negotiable:
+
+- **User-supplied text goes in the embed, never in `content`.** Only `content` parses
+  mentions, so a post body saying `@everyone` in an embed pings nobody. The `@everyone`
+  we do send is text we author.
+- **Sending must not be able to break a write.** `fetch` resolves on 4xx/5xx, so the
+  status is checked explicitly and failures are logged, never thrown; dispatch is
+  `waitUntil` so no user waits on Discord.
+
+`DISCORD_WEBHOOK_URL` is a **secret** (`wrangler secret put`) — it is a bearer
+credential. Unset = notifications off, which is the local-dev default.
+
 ## Database — Supabase + Drizzle
 
 App data (forum, users) lives in **Supabase Postgres**, accessed with **Drizzle ORM**. Full workflow in `docs/DATABASE.md`. The load-bearing rules:

--- a/backend/src/forum/routes.ts
+++ b/backend/src/forum/routes.ts
@@ -6,6 +6,7 @@ import { posts, comments, profiles, votes } from '../db/schema';
 import { requireAuth, type AuthVars } from '../middleware/auth';
 import { createPostSchema, createCommentSchema, voteSchema, unvoteSchema } from './validation';
 import { resolvePageSize, resolveOffset } from './pagination';
+import { notify } from '../notify';
 
 const forum = new Hono<{ Bindings: Bindings; Variables: AuthVars }>();
 
@@ -15,7 +16,8 @@ const commentScore = sql<number>`coalesce((select sum(${votes.value})::int from 
 // Workers Cache is on (wrangler.jsonc): a response with NO Cache-Control is still
 // cached (RFC 9111 heuristic TTL). Reads opt into a short TTL under one tag and every
 // write purges it, so posts/comments/votes show up at once, not after the TTL.
-// REMINDER: any new forum-mutating route MUST call purgeForum(c). And a per-user read
+// REMINDER: any new forum-mutating route MUST call purgeForum(c) and notify(c, ...).
+// And a per-user read
 // (e.g. a future GET /votes/mine for the upvote fix) MUST set Cache-Control: no-store;
 // never cache per-user data behind a shared cache. See the cache rule in AGENTS.md.
 const FORUM_CACHE = 'public, max-age=30, stale-while-revalidate=600';
@@ -100,6 +102,13 @@ forum.post('/posts', requireAuth, async (c) => {
       .returning(),
   );
   purgeForum(c);
+  notify(c, {
+    kind: 'post',
+    title: post.title,
+    description: post.content,
+    actor: profile.username,
+    path: `/forum/${post.id}`,
+  });
   return c.json(post, 201);
 });
 
@@ -114,6 +123,13 @@ forum.post('/posts/:id/comments', requireAuth, async (c) => {
       .returning(),
   );
   purgeForum(c);
+  notify(c, {
+    kind: 'comment',
+    title: 'New comment',
+    description: comment.content,
+    actor: profile.username,
+    path: `/forum/${c.req.param('id')}`,
+  });
   return c.json(comment, 201);
 });
 

--- a/backend/src/notify.ts
+++ b/backend/src/notify.ts
@@ -1,0 +1,67 @@
+// Discord webhook pings for forum activity. An unset DISCORD_WEBHOOK_URL is a
+// no-op, so local dev and CI stay silent instead of posting to the real channel.
+import type { Context } from 'hono';
+import type { Bindings } from './types';
+
+const COLORS = { post: 0x5865f2, comment: 0x57f287, digest: 0x9b59b6 } as const;
+
+export type NotifyEvent = {
+  kind: keyof typeof COLORS;
+  title: string;
+  description?: string;
+  actor?: string;
+  path?: string;
+  ping?: boolean;
+};
+
+// Discord rejects the whole message if any embed field is over length (title 256,
+// description 4096). 1000 is a readability cap, well inside the limit.
+const clip = (s: string, max: number) => (s.length > max ? `${s.slice(0, max - 1)}…` : s);
+
+// Only `content` pings — mentions inside an embed render as text and notify nobody.
+// User-supplied title/body therefore goes in the embed, where a post that says
+// "@everyone" cannot ping the server; the ping lives in content we author.
+export async function send(env: Bindings, e: NotifyEvent): Promise<void> {
+  if (!env.DISCORD_WEBHOOK_URL) return;
+  const ping = e.ping !== false;
+
+  try {
+    // ?wait=true so a rejected message comes back as a real error body, not a bare 204.
+    const res = await fetch(`${env.DISCORD_WEBHOOK_URL}?wait=true`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        content: ping ? '@everyone' : undefined,
+        allowed_mentions: { parse: ping ? ['everyone'] : [] },
+        embeds: [
+          {
+            title: clip(e.title, 256),
+            description: e.description ? clip(e.description, 1000) : undefined,
+            url: e.path ? `${env.FRONTEND_URL}${e.path}` : undefined,
+            color: COLORS[e.kind],
+            timestamp: new Date().toISOString(),
+            author: e.actor ? { name: clip(e.actor, 256) } : undefined,
+          },
+        ],
+      }),
+    });
+    // fetch only rejects on network failure: 400/401/429 arrive as ordinary responses,
+    // so without this check a revoked webhook fails completely silently.
+    if (!res.ok) console.error(`discord webhook ${res.status}:`, await res.text());
+  } catch (err) {
+    console.error('discord webhook failed:', err);
+  }
+}
+
+// Fire-and-forget. The DB write has already committed by the time this runs, so
+// nothing here may throw into the handler or make the user wait on Discord.
+// Generic over the env: Hono's Context is invariant, so a concrete
+// Context<{ Bindings }> would reject a route that also declares Variables.
+export function notify<E extends { Bindings: Bindings }>(c: Context<E>, e: NotifyEvent): void {
+  const sent = send(c.env, e);
+  try {
+    c.executionCtx.waitUntil(sent);
+  } catch {
+    // No ExecutionContext (app.request in tests); the send still runs, unawaited.
+  }
+}

--- a/backend/src/scheduled.ts
+++ b/backend/src/scheduled.ts
@@ -1,14 +1,21 @@
 // src/scheduled.ts
 //
-// Cron handler. For now just a keep-alive: one trivial query so the Supabase
-// free tier doesn't pause the project after ~7 days idle. Fired by the cron in
-// wrangler.jsonc — deliberately not wired to /health, which stays cheap/public.
-import { sql } from 'drizzle-orm';
+// Cron handler for the two schedules in wrangler.jsonc, dispatched on event.cron:
+//   00:00 UTC — keep-alive: one trivial query so the Supabase free tier doesn't
+//               pause the project after ~7 days idle. Deliberately not wired to
+//               /health, which stays cheap/public.
+//   01:00 UTC — daily forum digest to Discord. Also a canary: the webhook can't
+//               report its own death, so a missing digest is the signal.
+import { gt, sql } from 'drizzle-orm';
 import { getDb } from './db';
+import { posts, comments } from './db/schema';
+import { send } from './notify';
 import type { Bindings } from './types';
 
-export async function scheduled(_event: ScheduledController, env: Bindings, ctx: ExecutionContext): Promise<void> {
-  ctx.waitUntil(keepAlive(env));
+const DIGEST_CRON = '0 1 * * *';
+
+export async function scheduled(event: ScheduledController, env: Bindings, ctx: ExecutionContext): Promise<void> {
+  ctx.waitUntil(event.cron === DIGEST_CRON ? digest(env) : keepAlive(env));
 }
 
 async function keepAlive(env: Bindings): Promise<void> {
@@ -17,6 +24,29 @@ async function keepAlive(env: Bindings): Promise<void> {
     await db.execute(sql`SELECT 1;`);
   } catch (err) {
     console.error('keep-alive query failed:', err);
+  } finally {
+    await db.$client.end();
+  }
+}
+
+async function digest(env: Bindings): Promise<void> {
+  const db = getDb(env);
+  try {
+    const since = sql`now() - interval '24 hours'`;
+    const [newPosts, newComments] = await Promise.all([
+      db.$count(posts, gt(posts.createdAt, since)),
+      db.$count(comments, gt(comments.createdAt, since)),
+    ]);
+    // No ping: this fires daily and its job is to be present, not to interrupt.
+    await send(env, {
+      kind: 'digest',
+      title: 'Daily digest',
+      description: `Last 24h: ${newPosts} post(s), ${newComments} comment(s).`,
+      path: '/forum',
+      ping: false,
+    });
+  } catch (err) {
+    console.error('digest failed:', err);
   } finally {
     await db.$client.end();
   }

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -22,4 +22,12 @@ export type Bindings = {
   // SUPABASE_URL: project API URL — a non-secret var, set in wrangler.jsonc.
   DATABASE_URL: string;
   SUPABASE_URL: string;
+
+  // Origin of the Next.js frontend — the mirror of the frontend's NEXT_PUBLIC_API_URL.
+  // Used to link notifications back into the forum. Non-secret var in wrangler.jsonc.
+  FRONTEND_URL: string;
+
+  // Discord webhook for forum activity pings. A bearer credential — anyone holding
+  // it can post to the channel — so `wrangler secret put`. Unset = notifications off.
+  DISCORD_WEBHOOK_URL: string;
 };

--- a/backend/test/notify.test.ts
+++ b/backend/test/notify.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { send } from '../src/notify';
+import type { Bindings } from '../src/types';
+
+const env = {
+  DISCORD_WEBHOOK_URL: 'https://discord.com/api/webhooks/1/token',
+  FRONTEND_URL: 'https://cccsolutions.ca',
+} as Bindings;
+
+function mockFetch(res: Response | Error) {
+  const fn = vi.fn<(url: string, init?: RequestInit) => Promise<Response>>(() =>
+    res instanceof Error ? Promise.reject(res) : Promise.resolve(res),
+  );
+  vi.stubGlobal('fetch', fn);
+  return fn;
+}
+
+const ok = () => new Response('{}', { status: 200 });
+
+function bodyOf(fn: ReturnType<typeof mockFetch>) {
+  return JSON.parse((fn.mock.calls[0][1] as RequestInit).body as string);
+}
+
+beforeEach(() => {
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('send', () => {
+  it('is a no-op when the webhook is unset', async () => {
+    const fetchMock = mockFetch(ok());
+    await send({ ...env, DISCORD_WEBHOOK_URL: '' } as Bindings, { kind: 'post', title: 'hi' });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('keeps user-supplied text in the embed so it cannot ping the server', async () => {
+    const fetchMock = mockFetch(ok());
+    await send(env, { kind: 'post', title: '@everyone free robux', description: '@here too' });
+
+    const body = bodyOf(fetchMock);
+    expect(body.content).toBe('@everyone');
+    expect(body.embeds[0].title).toBe('@everyone free robux');
+    expect(body.embeds[0].description).toBe('@here too');
+  });
+
+  it('pings by default and stays silent when ping is false', async () => {
+    let fetchMock = mockFetch(ok());
+    await send(env, { kind: 'post', title: 'x' });
+    expect(bodyOf(fetchMock).allowed_mentions).toEqual({ parse: ['everyone'] });
+
+    fetchMock = mockFetch(ok());
+    await send(env, { kind: 'digest', title: 'x', ping: false });
+    const body = bodyOf(fetchMock);
+    expect(body.content).toBeUndefined();
+    expect(body.allowed_mentions).toEqual({ parse: [] });
+  });
+
+  it('builds the embed link from FRONTEND_URL and omits it without a path', async () => {
+    let fetchMock = mockFetch(ok());
+    await send(env, { kind: 'post', title: 'x', path: '/forum/abc' });
+    expect(bodyOf(fetchMock).embeds[0].url).toBe('https://cccsolutions.ca/forum/abc');
+
+    fetchMock = mockFetch(ok());
+    await send(env, { kind: 'post', title: 'x' });
+    expect(bodyOf(fetchMock).embeds[0].url).toBeUndefined();
+  });
+
+  it('clips over-long text so Discord does not reject the whole message', async () => {
+    const fetchMock = mockFetch(ok());
+    await send(env, { kind: 'post', title: 'a'.repeat(500), description: 'b'.repeat(5000) });
+
+    const embed = bodyOf(fetchMock).embeds[0];
+    expect(embed.title).toHaveLength(256);
+    expect(embed.description).toHaveLength(1000);
+    expect(embed.description.endsWith('…')).toBe(true);
+  });
+
+  it('requests ?wait=true so Discord returns a real error body', async () => {
+    const fetchMock = mockFetch(ok());
+    await send(env, { kind: 'post', title: 'x' });
+    expect(fetchMock.mock.calls[0][0]).toBe(`${env.DISCORD_WEBHOOK_URL}?wait=true`);
+  });
+
+  // fetch resolves on 4xx/5xx, so without the res.ok check these fail silently.
+  it('logs an HTTP error instead of swallowing it', async () => {
+    mockFetch(new Response('unauthorized', { status: 401 }));
+    await expect(send(env, { kind: 'post', title: 'x' })).resolves.toBeUndefined();
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('401'), 'unauthorized');
+  });
+
+  it('logs a network failure without rejecting into the caller', async () => {
+    mockFetch(new Error('connection reset'));
+    await expect(send(env, { kind: 'post', title: 'x' })).resolves.toBeUndefined();
+    expect(console.error).toHaveBeenCalledWith('discord webhook failed:', expect.any(Error));
+  });
+});

--- a/backend/wrangler.jsonc
+++ b/backend/wrangler.jsonc
@@ -3,10 +3,13 @@
   "name": "cccsolutions-backend",
   "main": "src/index.ts",
   "compatibility_date": "2026-07-08",
-  // cron trigger for preventing supabase inactivity  
+  // Cron triggers (UTC). 00:00 keeps Supabase from pausing on idle; 01:00 posts the
+  // daily forum digest, which doubles as a canary — no digest means a dead webhook.
+  // Dispatched by cron string in src/scheduled.ts.
   "triggers": {
     "crons": [
-      "0 0 * * *"
+      "0 0 * * *",
+      "0 1 * * *"
     ]
   },
   // Explicit, not inherited: workers_dev defaults to true and preview_urls
@@ -28,6 +31,7 @@
   // ADMIN_TOKEN, R2_* — stay as `wrangler secret` and must never be added here.
   "vars": {
     "SUPABASE_URL": "https://ccjcesfbqlnosienatsz.supabase.co",
+    "FRONTEND_URL": "https://cccsolutions.ca",
   },
   // "kv_namespaces": [
   //   {
@@ -51,8 +55,10 @@
   // "ai": {
   //   "binding": "AI"
   // },
-  // "observability": {
-  //   "enabled": true,
-  //   "head_sampling_rate": 1
-  // }
+  // Workers Logs. On so console.error from the Discord sender is queryable in the
+  // dashboard instead of vanishing — a failed webhook can't announce itself.
+  "observability": {
+    "enabled": true,
+    "head_sampling_rate": 1,
+  },
 }


### PR DESCRIPTION
## Description

Nobody watches the forum all day, so new posts and comments sat unnoticed for hours. Every forum-mutating route now announces itself to a Discord webhook, right alongside the cache purge it already does.

Two non-obvious choices worth flagging for review:

**User text lives in the embed, never in `content`.** Only the top-level `content` field parses mentions — mentions inside an embed render as text and notify nobody. So a post body containing `@everyone` cannot ping the server, while the `@everyone` we author in `content` still does. That boundary is what makes pinging safe on a public forum.

**The status is checked explicitly.** `fetch` resolves on 4xx/5xx, so a revoked webhook, a 429, or a malformed embed would all have failed completely silently behind a bare `.catch()`. Failures are logged, never thrown — the DB write has already committed by the time the send runs, so a throw would 500 a post that actually exists. Dispatch is `waitUntil`, so no user waits on Discord's round trip.

The daily digest is a canary as much as a summary: a webhook can't report its own death, so a missing digest is the signal that it's broken.

## Changes

- `src/notify.ts` (new) — `send(env, event)` builds and posts the webhook payload; `notify(c, event)` wraps it in `waitUntil`. Hits `?wait=true` so Discord returns a real error body instead of a bare 204, and clips embed text so an over-long post can't get the whole message rejected.
- `src/forum/routes.ts` — `notify` on `POST /posts` and `POST /posts/:id/comments`. Votes deliberately excluded: webhooks cap at ~30 messages/min per channel and vote traffic would crowd out the notifications that matter.
- `src/scheduled.ts` — dispatches on `event.cron` between the existing keep-alive (00:00 UTC) and the new digest (01:00 UTC). The digest uses its own client so the keep-alive's `$client.end()` can't close the connection out from under it.
- `wrangler.jsonc` — `FRONTEND_URL` var, second cron trigger, and Workers Logs enabled so the error path is queryable rather than vanishing.
- `src/types.ts` / `.dev.vars.example` — new bindings. `DISCORD_WEBHOOK_URL` is a **secret** (bearer credential; anyone holding it can post to the channel) and is left empty in the example, so a fresh clone and local `wrangler dev` stay silent instead of posting to the live channel.
- `AGENTS.md` — documents the notify rule next to the existing cache-purge rules.

## Testing

- `test/notify.test.ts` (new, 8 cases): webhook-unset no-op, user text confined to the embed, ping vs. `ping: false`, link built from `FRONTEND_URL`, clipping, `?wait=true`, and both failure paths — an HTTP error and a network rejection — asserting each logs and neither rejects into the caller.
- `bun run typecheck`, `bun run lint`, `bun run format:check`, `bun run test` all clean locally. 52 tests pass; coverage 96.31% statements / 92.5% branches.
- `bunx wrangler deploy --dry-run` validates the config and shows `env.FRONTEND_URL` bound.
- Prod secret `DISCORD_WEBHOOK_URL` is already set. Note it is intentionally **not** in local `.dev.vars`, so nothing fires under `wrangler dev` until added; the digest can be fired on demand with `curl "http://localhost:8787/__scheduled?cron=0+1+*+*+*"`.

Deploy note: `wrangler deploy` replaces plaintext `vars` (now `SUPABASE_URL` + `FRONTEND_URL`) and leaves all secrets untouched.

## Checklist

- [x] I read CONTRIBUTING.md and gave my own code a once-over (it runs and does what the PR says)
- [x] `tsc`, lint, and tests pass locally (CI checks these too)
- [x] New backend feature code (`backend/src/`) has vitest tests
- [x] Code is formatted and matches the surrounding style (CI checks this)
- [x] Docs/comments updated if behavior or APIs changed
