### PR TITLE
ci: stop the stale bot from touching issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,23 +14,19 @@ jobs:
     steps:
       - uses: actions/stale@v10
         with:
-          days-before-stale: 60
-          days-before-close: 14
-          exempt-issue-labels: pinned,security,good first issue
+          # PRs only. An idle PR really is abandoned, but the issue tracker here is a
+          # long-lived roadmap: phase-3 work isn't stale, it just isn't due yet. -1
+          # disables both marking and closing for issues, so nothing auto-closes.
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+          days-before-pr-stale: 60
+          days-before-pr-close: 14
           exempt-pr-labels: pinned,security,good first issue
-          stale-issue-label: stale
           stale-pr-label: stale
-          stale-issue-message: >-
-            Hi! This issue has been quiet for a while, so we've marked it stale.
-            No rush — just comment if it's still relevant and we'll keep it open.
-            Otherwise it'll close in 14 days.
           stale-pr-message: >-
             Hi! This PR has been quiet for a while, so we've marked it stale.
             Push a commit or leave a comment when you're ready and we'll pick it
             back up. Otherwise it'll close in 14 days.
-          close-issue-message: >-
-            Closing this for now since it's been inactive. Feel free to reopen
-            anytime — no hard feelings!
           close-pr-message: >-
             Closing this for now since it's been inactive. Reopen whenever you'd
             like to continue. Thanks for contributing!


### PR DESCRIPTION
## Description

The stale bot has been marking 8 roadmap issues a night since Aug 11 (#57-65, #92-97, #106-115), and each batch was on a 14-day timer to auto-close. Those issues aren't abandoned — the tracker is a long-lived roadmap where `phase-3` work is *supposed* to sit untouched for months, so "no activity in 60 days" carries no signal about whether an item is still wanted.

Unmarking them by hand doesn't fix it: label removal bumps `updated_at`, which just buys 60 days before the same issues come back. This turns the premise off where it's false and leaves it on where it's true — an idle PR genuinely is abandoned.

The 8-a-night pacing was `actions/stale`'s default `operations-per-run: 30` chewing through the backlog, not a coincidence.

## Changes

- `days-before-issue-stale: -1` and `days-before-issue-close: -1` — disables marking *and* closing for issues. The second is belt-and-braces: even a manually-applied `stale` label can never lead to an auto-close.
- Splits the old shared `days-before-stale: 60` / `days-before-close: 14` into explicit `days-before-pr-*`, so PR behaviour is unchanged at 60/14.
- Drops `stale-issue-message`, `close-issue-message`, and `exempt-issue-labels` — all dead once issues are out of scope, and leaving them implies issues are still processed.
- `permissions: issues: write` stays: PRs are issues in the REST API, so labelling one needs it.

## Testing

- Cleared the `stale` label from all 8 issues marked this morning (#57-64); repo-wide count of `stale`-labelled issues and PRs is now 0.
- Config-only change to a scheduled workflow, so there's nothing to run locally — the real check is that tomorrow's 07:00 UTC run marks nothing. The next eligible batch would have been #47 and #49-56.

## Checklist

- [x] I read CONTRIBUTING.md and gave my own code a once-over (it runs and does what the PR says)
- [x] `tsc`, lint, and tests pass locally (CI checks these too)
- [ ] New backend feature code (`backend/src/`) has vitest tests — n/a, CI config only
- [x] Code is formatted and matches the surrounding style (CI checks this)
- [x] Docs/comments updated if behavior or APIs changed