### PR TITLE
fix(backend): scope cached reads to the edge (s-maxage), no-store the rest

### DIFF
--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -25,10 +25,16 @@ So every GET must decide, explicitly:
 
 - **Opt in:** set `Cache-Control` + a `Cache-Tag`, AND purge that tag on every write
   that changes what it returns (see the R2 rule below, and `purgeForum()` in
-  `src/forum/routes.ts`). No purge, no cache.
+  `src/forum/routes.ts`). No purge, no cache. **Use `s-maxage` (+ `max-age=0`), never a
+  bare `max-age`.** A tag purge clears the shared **edge** cache only; `max-age` is
+  obeyed by every client's browser too, so it would pin a stale copy the purge can't
+  reach (e.g. a user's own vote showing score 0 for the whole SWR window). `s-maxage`
+  scopes the TTL to the edge; `max-age=0` makes browsers revalidate every load.
 - **Opt out:** set `Cache-Control: no-store`. **Per-user responses MUST be `no-store`**
   — a shared cache would serve one user's data to another. (This is why the future
-  `GET /forum/votes/mine` must be `no-store`.)
+  `GET /forum/votes/mine` must be `no-store`.) This also covers real-time checks like
+  `GET /user/username-available` and liveness like `GET /health` — heuristic caching
+  would serve a stale answer.
 
 Forum reads are tagged `forum-posts`; every forum write purges it. Any new
 forum-mutating route (post/comment edit or delete, moderation, a profile edit that
@@ -37,11 +43,13 @@ changes the `author` fields) MUST purge `forum-posts` too.
 ## RULE: every R2 write MUST purge the contest cache tag
 
 `/list` and `/preview` are served with `Cache-Tag: contest:<year>:<code>` and an
-aggressive `max-age`. **Any endpoint that writes to R2 (upload, delete, overwrite)
-MUST purge that contest's cache tag**, or the cached `/list` + `/preview` go stale
-and a freshly staged/removed file stays invisible until the max-age expires.
+aggressive `s-maxage` (edge-only; see the `s-maxage` rule above — a week-long `max-age`
+would trap the stale list in every browser the purge can't reach). **Any endpoint that
+writes to R2 (upload, delete, overwrite) MUST purge that contest's cache tag**, or the
+cached `/list` + `/preview` go stale and a freshly staged/removed file stays invisible
+until the TTL expires.
 
-This purge is exactly what makes the aggressive caching safe. It is not optional.
+This purge is exactly what makes the aggressive caching safe (at the edge). It is not optional.
 Use the Workers Cache tag-purge (GA 2026-07-06), fired via `waitUntil`:
 
 ```ts
@@ -76,7 +84,7 @@ App data (forum, users) lives in **Supabase Postgres**, accessed with **Drizzle 
 - **Migrations run only in CI** (`.github/workflows/db-migrate.yml`): applied to a throwaway Supabase on PRs, to prod on merge to main. Never hand-edit the DB, never `db:push`. Drizzle owns the `public` schema only — Supabase owns `auth`/`storage`.
 - **Two connection strings.** `DATABASE_URL` = transaction pooler (6543), for the Worker at runtime — construct clients as `postgres(url, { max: 1, prepare: false })` (transaction pooling breaks server-side prepared statements). `DIRECT_DATABASE_URL` = session mode (5432), for migrations only, and it lives **only** as a CI secret so prod can't be migrated by hand.
 - **Keys:** use `SUPABASE_SECRET_KEY` (server) and `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` (browser) — the old `service_role`/`anon` keys are deprecated. Verify JWTs via JWKS off `SUPABASE_URL` (no `SUPABASE_JWT_SECRET`). `SUPABASE_URL` is a non-secret var in `wrangler.jsonc`, not a secret.
-- **RLS is currently inert.** The Worker connects as a privileged pooler role, so `auth.uid()` is NULL and `pgPolicy` rules are bypassed — authorization is enforced in the API layer. Defined policies are defense-in-depth until we set `request.jwt.claims` per request (planned; see `../docs/Roadmap40.md`).
+- **RLS is live on writes.** Writes go through `withUser()`, which sets `request.jwt.claims` + `role authenticated` per transaction (transaction-local, because the transaction pooler can hand a different backend connection to each statement), so `auth.uid()` resolves and `pgPolicy` rules apply. Reads run as the privileged pooler role and bypass RLS by design (public data); the API is the gatekeeper there. Policies also require table `GRANT`s to the `authenticated` role, or writes fail with `42P01` (see the grants migration).
 
 ## Migration / deploy notes
 

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -33,8 +33,8 @@ So every GET must decide, explicitly:
 - **Opt out:** set `Cache-Control: no-store`. **Per-user responses MUST be `no-store`**
   — a shared cache would serve one user's data to another. (This is why the future
   `GET /forum/votes/mine` must be `no-store`.) This also covers real-time checks like
-  `GET /user/username-available` and liveness like `GET /health` — heuristic caching
-  would serve a stale answer.
+  `GET /user/username-available` and liveness like `GET /health`, where heuristic
+  caching would serve a stale answer.
 
 Forum reads are tagged `forum-posts`; every forum write purges it. Any new
 forum-mutating route (post/comment edit or delete, moderation, a profile edit that
@@ -43,8 +43,8 @@ changes the `author` fields) MUST purge `forum-posts` too.
 ## RULE: every R2 write MUST purge the contest cache tag
 
 `/list` and `/preview` are served with `Cache-Tag: contest:<year>:<code>` and an
-aggressive `s-maxage` (edge-only; see the `s-maxage` rule above — a week-long `max-age`
-would trap the stale list in every browser the purge can't reach). **Any endpoint that
+aggressive `s-maxage` (edge-only; see the `s-maxage` rule above: a week-long `max-age`
+would trap the stale list in browsers the purge can't reach). **Any endpoint that
 writes to R2 (upload, delete, overwrite) MUST purge that contest's cache tag**, or the
 cached `/list` + `/preview` go stale and a freshly staged/removed file stays invisible
 until the TTL expires.

--- a/backend/src/forum/routes.ts
+++ b/backend/src/forum/routes.ts
@@ -21,10 +21,8 @@ const commentScore = sql<number>`coalesce((select sum(${votes.value})::int from 
 // (e.g. a future GET /votes/mine for the upvote fix) MUST set Cache-Control: no-store;
 // never cache per-user data behind a shared cache. See the cache rule in AGENTS.md.
 //
-// s-maxage (edge), not max-age (every cache incl. the browser): a purge only clears the
-// shared edge cache, so max-age would let a client's own browser pin a stale copy (e.g.
-// score 0 right after they voted) for the whole SWR window. max-age=0 makes browsers
-// revalidate; s-maxage keeps the edge cache + purge-on-write.
+// s-maxage caches at the edge only; max-age=0 stops a browser pinning a stale copy the
+// purge can't reach (e.g. their own vote still showing score 0).
 const FORUM_CACHE = 'public, max-age=0, s-maxage=30, stale-while-revalidate=600';
 
 function purgeForum(c: Context<{ Bindings: Bindings; Variables: AuthVars }>): void {

--- a/backend/src/forum/routes.ts
+++ b/backend/src/forum/routes.ts
@@ -20,7 +20,12 @@ const commentScore = sql<number>`coalesce((select sum(${votes.value})::int from 
 // And a per-user read
 // (e.g. a future GET /votes/mine for the upvote fix) MUST set Cache-Control: no-store;
 // never cache per-user data behind a shared cache. See the cache rule in AGENTS.md.
-const FORUM_CACHE = 'public, max-age=30, stale-while-revalidate=600';
+//
+// s-maxage (edge), not max-age (every cache incl. the browser): a purge only clears the
+// shared edge cache, so max-age would let a client's own browser pin a stale copy (e.g.
+// score 0 right after they voted) for the whole SWR window. max-age=0 makes browsers
+// revalidate; s-maxage keeps the edge cache + purge-on-write.
+const FORUM_CACHE = 'public, max-age=0, s-maxage=30, stale-while-revalidate=600';
 
 function purgeForum(c: Context<{ Bindings: Bindings; Variables: AuthVars }>): void {
   const ctx = c.executionCtx as unknown as ExecutionContext;

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -26,8 +26,7 @@ function isAllowedOrigin(origin: string): boolean {
 
 app.use('*', cors({ origin: (origin) => (origin && isAllowedOrigin(origin) ? origin : undefined) }));
 
-// no-store on both: with no Cache-Control, Workers Cache heuristically caches the
-// response, so /health would report a stale snapshot instead of live state. See AGENTS.md.
+// no-store: with no header, Workers Cache serves a stale snapshot (see AGENTS.md).
 app.get('/', (c) => {
   c.header('Cache-Control', 'no-store');
   return c.json({ name: 'cccsolutions-api', version: 'v1' });

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -26,12 +26,16 @@ function isAllowedOrigin(origin: string): boolean {
 
 app.use('*', cors({ origin: (origin) => (origin && isAllowedOrigin(origin) ? origin : undefined) }));
 
+// no-store on both: with no Cache-Control, Workers Cache heuristically caches the
+// response, so /health would report a stale snapshot instead of live state. See AGENTS.md.
 app.get('/', (c) => {
+  c.header('Cache-Control', 'no-store');
   return c.json({ name: 'cccsolutions-api', version: 'v1' });
   // TODO: expand with available endpoints / links / more API info
 });
 
 app.get('/health', (c) => {
+  c.header('Cache-Control', 'no-store');
   return c.json({ status: 'ok' });
   // TODO: deeper checks — R2, DB, downstream services (not just liveness)
 });

--- a/backend/src/r2/routes.ts
+++ b/backend/src/r2/routes.ts
@@ -7,13 +7,8 @@ import { problemParamsSchema, fileSchema } from './validation';
 
 const r2 = new Hono<{ Bindings: Bindings }>();
 
-// Cached a full week at the EDGE: safe only because every R2 write (admin upload/delete)
-// purges the contest's cache tag via Workers Cache (GA), see the rule in AGENTS.md.
-// That purge reaches the edge only, so this MUST use s-maxage, not max-age — a bare
-// max-age would let each client's browser pin the stale list/preview for up to a week
-// (a freshly staged/removed file would stay invisible), unreachable by the purge.
-// max-age=0 makes browsers revalidate. Cache-Tag lets the purge target only this
-// contest's entries; Cloudflare strips Cache-Tag before it reaches the client.
+// Edge-cached a week. R2 writes purge the Cache-Tag, but a purge only clears the shared
+// edge, so use s-maxage (not max-age) or browsers keep a stale list/preview. See AGENTS.md.
 function setContestCache(c: Context, year: string, code: string): void {
   c.header('Cache-Control', 'public, max-age=0, s-maxage=604800, stale-while-revalidate=2592000');
   c.header('Cache-Tag', `contest:${year}:${code}`);

--- a/backend/src/r2/routes.ts
+++ b/backend/src/r2/routes.ts
@@ -7,12 +7,15 @@ import { problemParamsSchema, fileSchema } from './validation';
 
 const r2 = new Hono<{ Bindings: Bindings }>();
 
-// Cached a full week: this is safe because every R2 write (admin upload/delete)
-// purges the contest's cache tag via Workers Cache (GA), please see the rule in AGENTS.md.
-// Cache-Tag lets that purge target only this contest's entries; Cloudflare strips
-// Cache-Tag before it reaches the client.
+// Cached a full week at the EDGE: safe only because every R2 write (admin upload/delete)
+// purges the contest's cache tag via Workers Cache (GA), see the rule in AGENTS.md.
+// That purge reaches the edge only, so this MUST use s-maxage, not max-age — a bare
+// max-age would let each client's browser pin the stale list/preview for up to a week
+// (a freshly staged/removed file would stay invisible), unreachable by the purge.
+// max-age=0 makes browsers revalidate. Cache-Tag lets the purge target only this
+// contest's entries; Cloudflare strips Cache-Tag before it reaches the client.
 function setContestCache(c: Context, year: string, code: string): void {
-  c.header('Cache-Control', 'public, max-age=604800, stale-while-revalidate=2592000');
+  c.header('Cache-Control', 'public, max-age=0, s-maxage=604800, stale-while-revalidate=2592000');
   c.header('Cache-Tag', `contest:${year}:${code}`);
 }
 

--- a/backend/src/user/routes.ts
+++ b/backend/src/user/routes.ts
@@ -7,8 +7,7 @@ import { requireAuth, type AuthVars } from '../middleware/auth';
 
 const user = new Hono<{ Bindings: Bindings; Variables: AuthVars }>();
 
-// no-store: per-user data. Without it Workers Cache could heuristically cache one
-// user's profile and serve it to another (see the cache rule in AGENTS.md).
+// no-store: per-user data must never be shared-cached (see AGENTS.md).
 user.get('/me', requireAuth, (c) => {
   c.header('Cache-Control', 'no-store');
   return c.json(c.get('profile'));
@@ -16,8 +15,7 @@ user.get('/me', requireAuth, (c) => {
 
 // Public. Taken only if a CLAIMED profile holds the name; unclaimed migrated profiles
 // are reclaimable (see getOrCreateProfile), so they still count as available.
-// no-store: a real-time availability check must not be cached, or a name taken seconds
-// ago still reports available for the heuristic TTL.
+// no-store: a real-time check must not be cached.
 user.get('/username-available', async (c) => {
   c.header('Cache-Control', 'no-store');
   const username = (c.req.query('u') ?? '').toLowerCase();

--- a/backend/src/user/routes.ts
+++ b/backend/src/user/routes.ts
@@ -7,11 +7,19 @@ import { requireAuth, type AuthVars } from '../middleware/auth';
 
 const user = new Hono<{ Bindings: Bindings; Variables: AuthVars }>();
 
-user.get('/me', requireAuth, (c) => c.json(c.get('profile')));
+// no-store: per-user data. Without it Workers Cache could heuristically cache one
+// user's profile and serve it to another (see the cache rule in AGENTS.md).
+user.get('/me', requireAuth, (c) => {
+  c.header('Cache-Control', 'no-store');
+  return c.json(c.get('profile'));
+});
 
 // Public. Taken only if a CLAIMED profile holds the name; unclaimed migrated profiles
 // are reclaimable (see getOrCreateProfile), so they still count as available.
+// no-store: a real-time availability check must not be cached, or a name taken seconds
+// ago still reports available for the heuristic TTL.
 user.get('/username-available', async (c) => {
+  c.header('Cache-Control', 'no-store');
   const username = (c.req.query('u') ?? '').toLowerCase();
   if (!/^[a-z0-9_]{2,24}$/.test(username)) return c.json({ available: false });
   const db = getDb(c.env);

--- a/backend/test/r2/routes.test.ts
+++ b/backend/test/r2/routes.test.ts
@@ -205,7 +205,7 @@ describe('GET /contests/:year/:code/list', () => {
 });
 
 describe('Workers Cache headers', () => {
-  const CACHE_CONTROL = 'public, max-age=604800, stale-while-revalidate=2592000';
+  const CACHE_CONTROL = 'public, max-age=0, s-maxage=604800, stale-while-revalidate=2592000';
 
   it('/list is cacheable and tagged by contest', async () => {
     const bucket = bucketListing([['contests/2024/s1/tests/1.in', 100]]);


### PR DESCRIPTION
## Description

A `Cache-Tag` purge clears only the shared **edge** cache, but `max-age` is obeyed by every client's **browser** too — so a browser can pin a stale copy the purge can never reach. Symptom in prod: right after voting, the forum list showed **score 0 in that user's own browser** (their browser had cached the pre-vote list for the `stale-while-revalidate` window) while other clients — a phone, the edge — saw the correct score. `Cmd+Shift+R` fixed it, which pointed straight at browser-side caching.

The fix is to scope every cached read to the edge with `s-maxage` (+ `max-age=0` so browsers revalidate), and to explicitly `no-store` the routes that were being heuristically cached with no header at all.

## Changes

- **Forum reads** (`FORUM_CACHE`) and **R2 `/list` + `/preview`** (`setContestCache`): `s-maxage` (edge TTL) + `max-age=0` instead of a bare `max-age`. Same edge caching and purge-on-write behaviour, but browsers no longer pin stale copies. R2's `max-age` was a **full week** — a freshly staged/removed file could stay invisible in a browser for up to 7 days despite the write purging the edge.
- **`no-store`** added to `GET /user/me` (per-user profile — a shared cache could serve one user's data to another), `GET /user/username-available` (real-time check feeding signup — a name taken seconds ago must not still report available), and `GET /` + `GET /health` (both had no `Cache-Control` and were being heuristically cached — confirmed `cf-cache-status: HIT` in prod).
- **`AGENTS.md`**: documented the `max-age`-vs-`s-maxage` rule (a purge is edge-only, so shared-cache reads must use `s-maxage`), annotated the R2 rule accordingly, and corrected the stale `RLS is currently inert` line to `RLS is live on writes` (it has been since the `withUser()` + grants work shipped).

## Testing

- `tsc --noEmit`, `eslint`, and `prettier --check` all clean locally.
- Confirmed the bugs in prod before the fix: `/health` and `/user/username-available` both returned `cf-cache-status: MISS` then `HIT` on a second call (heuristically cached); the forum list served a stale score in-browser that a hard refresh cleared.
- No behaviour change at the edge — `s-maxage` preserves the existing edge TTL and the existing tag-purge-on-write path.

## Linked issues

Refs #

## Checklist

- [x] I gave my own code a once-over (it runs and does what the PR says)
- [x] `tsc`, lint, and format pass locally (CI checks these too)
- [ ] New backend feature code (`backend/src/`) has vitest tests — N/A (header-only change, no new logic)
- [x] Code is formatted and matches the surrounding style
- [x] Docs/comments updated (AGENTS.md + inline comments on each header)