### PR TITLE
fix: stop serving stale forum scores (drop SWR) + dedupe profile/posts fetches

### DIFF
--- a/backend/src/forum/routes.ts
+++ b/backend/src/forum/routes.ts
@@ -22,8 +22,12 @@ const commentScore = sql<number>`coalesce((select sum(${votes.value})::int from 
 // never cache per-user data behind a shared cache. See the cache rule in AGENTS.md.
 //
 // s-maxage caches at the edge only; max-age=0 stops a browser pinning a stale copy the
-// purge can't reach (e.g. their own vote still showing score 0).
-const FORUM_CACHE = 'public, max-age=0, s-maxage=30, stale-while-revalidate=600';
+// purge can't reach. No stale-while-revalidate: SWR serves the OLD cached body while it
+// revalidates in the background, so a user who just voted gets shown the pre-vote score
+// for the whole SWR window. Without it, an expired edge entry revalidates before serving,
+// so the just-voted user always sees the fresh score (the purge + short s-maxage keep it
+// cheap).
+const FORUM_CACHE = 'public, max-age=0, s-maxage=30';
 
 function purgeForum(c: Context<{ Bindings: Bindings; Variables: AuthVars }>): void {
   const ctx = c.executionCtx as unknown as ExecutionContext;

--- a/website/app/forum/page.tsx
+++ b/website/app/forum/page.tsx
@@ -58,30 +58,41 @@ export default function ForumPage() {
   const session = state === 'in';
   const { push } = useRouter();
 
-  const fetchPosts = useCallback(async () => {
-    try {
+  const fetchPosts = useCallback(
+    async (signal?: AbortSignal) => {
       setLoading(true);
       setError(false);
-      const offset = (page - 1) * perPage;
-      const res = await apiFetch(`/forum/posts?sort=${sortBy}&limit=${perPage}&offset=${offset}`);
-      if (!res.ok) throw new Error(`Failed to load posts (${res.status})`);
-      const data = await res.json();
-      // Tolerate an unexpected/old shape: Workers Cache can serve a pre-deploy array
-      // response for up to its TTL, and a malformed body must never crash the page.
-      const list: PostRow[] = Array.isArray(data) ? data : (data?.posts ?? []);
-      setPosts(list);
-      setTotal(Array.isArray(data) ? list.length : (data?.total ?? list.length));
-    } catch (err) {
-      console.error('Error fetching posts:', err);
-      setError(true);
-      toast.error('Could not load posts.');
-    } finally {
-      setLoading(false);
-    }
-  }, [sortBy, page, perPage]);
+      try {
+        const offset = (page - 1) * perPage;
+        const res = await apiFetch(
+          `/forum/posts?sort=${sortBy}&limit=${perPage}&offset=${offset}`,
+          { signal }
+        );
+        if (!res.ok) throw new Error(`Failed to load posts (${res.status})`);
+        const data = await res.json();
+        // Tolerate an unexpected/old shape: Workers Cache can serve a pre-deploy array
+        // response for up to its TTL, and a malformed body must never crash the page.
+        const list: PostRow[] = Array.isArray(data) ? data : (data?.posts ?? []);
+        setPosts(list);
+        setTotal(Array.isArray(data) ? list.length : (data?.total ?? list.length));
+        setLoading(false);
+      } catch (err) {
+        // A superseded fetch (deps changed / unmount) aborts on purpose — the new
+        // fetch owns the loading + error state, so don't touch it here.
+        if (err instanceof DOMException && err.name === 'AbortError') return;
+        console.error('Error fetching posts:', err);
+        setError(true);
+        setLoading(false);
+        toast.error('Could not load posts.');
+      }
+    },
+    [sortBy, page, perPage]
+  );
 
   useEffect(() => {
-    fetchPosts();
+    const controller = new AbortController();
+    fetchPosts(controller.signal);
+    return () => controller.abort();
   }, [fetchPosts]);
 
   const totalPages = Math.max(1, Math.ceil(total / perPage));

--- a/website/components/auth/SupabaseAuthProvider.tsx
+++ b/website/components/auth/SupabaseAuthProvider.tsx
@@ -49,32 +49,30 @@ export function SupabaseAuthProvider({ children }: { children: React.ReactNode }
 
   useEffect(() => {
     let active = true;
+    let currentUserId: string | null = null;
 
-    supabase.auth.getSession().then(async ({ data }) => {
-      if (!active) return;
-      setSession(data.session);
-      if (data.session) {
-        const p = await fetchProfile();
-        if (!active) return;
-        setProfile(p);
-        setState('in');
-      } else {
-        setState('out');
-      }
-    });
-
+    // onAuthStateChange emits INITIAL_SESSION on subscribe, so it covers the initial
+    // load too — a separate getSession() fetch would just fire /user/me a second time.
     const { data: listener } = supabase.auth.onAuthStateChange(async (_event, s) => {
       if (!active) return;
       setSession(s);
-      if (s) {
-        const p = await fetchProfile();
-        if (!active) return;
-        setProfile(p);
-        setState('in');
-      } else {
+
+      if (!s) {
+        currentUserId = null;
         setProfile(null);
         setState('out');
+        return;
       }
+
+      // The listener also fires on token refresh; only refetch the profile when the
+      // signed-in user actually changes, so /user/me runs once per login, not per event.
+      if (s.user.id === currentUserId) return;
+      currentUserId = s.user.id;
+
+      const p = await fetchProfile();
+      if (!active) return;
+      setProfile(p);
+      setState('in');
     });
 
     return () => {


### PR DESCRIPTION
## Description

Two related forum freshness bugs, reproduced end-to-end in a real browser (Playwright).

**1. A user who just voted saw the *pre-vote* score after reloading** — and only a *second* reload fixed it. Proven: after an upvote, a `no-store` fetch returned the correct `score:1`, but the page's normal fetch came back `cf-cache-status: EXPIRED` and rendered `0`. Root cause is `stale-while-revalidate=600` on the forum reads: once the edge entry passes its 30s `s-maxage`, the edge serves the **old** body and revalidates in the background, so the *first* reload shows stale and only the *next* one is fresh. `s-maxage` (#215) fixed browser pinning but not this edge-side staleness.

**2. `/user/me` and `/forum/posts` each fired twice per load** (confirmed in the network panel — one `/posts` even landed `ABORTED`).

## Changes

- **`backend/src/forum/routes.ts`** — drop `stale-while-revalidate` from `FORUM_CACHE` (`public, max-age=0, s-maxage=30`). An expired edge entry now revalidates *before* serving, so a just-voted user always gets the fresh score. The short `s-maxage` + purge-on-write keep it cheap; no SWR window to serve a stale aggregate the voter just changed.
- **`website/components/auth/SupabaseAuthProvider.tsx`** — fetch the profile once. `onAuthStateChange` already emits `INITIAL_SESSION`, so the separate `getSession()` fetch was a redundant second `/user/me`. Now keyed on the user id so token-refresh events don't refetch.
- **`website/app/forum/page.tsx`** — run the list fetch under an `AbortController`; a superseded/duplicate request aborts cleanly (and is ignored in `catch`) instead of racing to overwrite state or flipping the page into an error toast.

## Testing

- Backend `tsc`, `eslint`, `prettier`, and vitest (52 passing) all clean.
- Website `tsc` + `eslint` clean.
- Reproduced the stale-score bug in Playwright pre-fix (upvote → reload shows 0, server returns 1); the SWR drop is what makes an expired edge entry serve fresh.

## Linked issues

Refs #

## Checklist

- [x] I gave my own code a once-over (it runs and does what the PR says)
- [x] `tsc`, lint, and format pass locally
- [ ] New backend feature code has vitest tests — N/A (cache-header value change; existing forum tests still green)
- [x] Code is formatted and matches the surrounding style
- [x] Docs/comments updated (inline rationale on the header + both dedupe sites)