### PR TITLE
fix(auth): survive email-link prescan + captcha reset + dup-email + expired-link handling

### DIFF
--- a/website/app/auth/confirm/page.tsx
+++ b/website/app/auth/confirm/page.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import { useEffect, useState, Suspense } from 'react';
+import Link from 'next/link';
+import { useRouter, useSearchParams } from 'next/navigation';
+import type { EmailOtpType } from '@supabase/supabase-js';
+import { supabase } from '../../../lib/supabase';
+import { Button } from '../../../components/ui/button';
+
+// Email links land here instead of Supabase's /auth/v1/verify. That endpoint consumes
+// the token on a raw GET, so Microsoft/Outlook "Safe Links" scanners — which pre-fetch
+// every link in an email — burn it before the user clicks. This page instead runs
+// verifyOtp in client JS (which scanners don't execute), so the token survives the
+// prescan and is only spent when a real browser loads the page. The 6-digit code in the
+// same email is the fallback for the rare scanner that does execute JS.
+
+// Where to send the user after a successful verify, keyed by OTP type.
+const DEST: Partial<Record<EmailOtpType, string>> = {
+  recovery: '/update-password',
+};
+
+const VALID_TYPES: EmailOtpType[] = ['signup', 'recovery', 'email', 'email_change', 'invite', 'magiclink'];
+
+function Centered({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="min-h-[calc(100svh-var(--nav-h))] flex items-center justify-center px-4 bg-background text-foreground">
+      <div className="w-full max-w-md text-center">{children}</div>
+    </div>
+  );
+}
+
+function ConfirmHandler() {
+  const router = useRouter();
+  const params = useSearchParams();
+  const [status, setStatus] = useState<'verifying' | 'error'>('verifying');
+
+  const rawType = params.get('type');
+  const type: EmailOtpType = VALID_TYPES.includes(rawType as EmailOtpType)
+    ? (rawType as EmailOtpType)
+    : 'signup';
+
+  useEffect(() => {
+    const tokenHash = params.get('token_hash');
+    if (!tokenHash) {
+      setStatus('error');
+      return;
+    }
+
+    let active = true;
+    supabase.auth.verifyOtp({ token_hash: tokenHash, type }).then(({ error }) => {
+      if (!active) return;
+      if (error) {
+        setStatus('error');
+        return;
+      }
+      router.replace(DEST[type] ?? '/forum');
+    });
+
+    return () => {
+      active = false;
+    };
+  }, [params, type, router]);
+
+  if (status === 'verifying') {
+    return (
+      <Centered>
+        <p className="text-foreground-light">Confirming…</p>
+      </Centered>
+    );
+  }
+
+  // The link expired, was already used, or was consumed by an email scanner. Point the
+  // user at the 6-digit code, which never has this problem.
+  const codeHref = type === 'recovery' ? '/reset-password' : '/signup';
+  return (
+    <Centered>
+      <h1 className="text-2xl font-semibold tracking-tight mb-3">This link didn&apos;t work</h1>
+      <p className="text-foreground-light mb-6">
+        It may have expired, already been used, or been pre-scanned by your email provider.
+        Enter the <span className="text-foreground font-medium">6-digit code</span> from the same
+        email instead, or request a new one.
+      </p>
+      <div className="flex justify-center gap-3">
+        <Button asChild type="primary" size="medium">
+          <Link href={codeHref}>Enter the code</Link>
+        </Button>
+        <Button asChild type="default" size="medium">
+          <Link href="/login">Back to login</Link>
+        </Button>
+      </div>
+    </Centered>
+  );
+}
+
+export default function AuthConfirmPage() {
+  return (
+    <Suspense
+      fallback={
+        <Centered>
+          <p className="text-foreground-light">Loading…</p>
+        </Centered>
+      }
+    >
+      <ConfirmHandler />
+    </Suspense>
+  );
+}

--- a/website/components/auth/AuthForm.tsx
+++ b/website/components/auth/AuthForm.tsx
@@ -8,7 +8,7 @@ import { supabase, apiFetch } from '../../lib/supabase';
 import { FlickeringGrid } from '../effects/FlickeringGrid';
 import { Button } from '../ui/button';
 import { Card, CardContent } from '../ui/card';
-import { TurnstileWidget } from './TurnstileWidget';
+import { TurnstileWidget, type TurnstileHandle } from './TurnstileWidget';
 
 const inputClass =
   'w-full h-10 px-3 rounded-md border border-border-strong bg-surface-100 text-sm text-foreground placeholder:text-foreground-lighter focus:outline-none focus:border-brand-highlight';
@@ -53,8 +53,18 @@ export default function AuthForm({ mode }: { mode: Mode }) {
   const [checkEmail, setCheckEmail] = useState(false);
   const [code, setCode] = useState('');
   const submittingRef = useRef(false);
+  const turnstileRef = useRef<TurnstileHandle>(null);
 
   const captchaRequired = !!process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY;
+
+  // A Turnstile token is single-use; after a completed submit, reset the widget so the
+  // next attempt gets a fresh token instead of the spent one (which Supabase rejects as
+  // "timeout-or-duplicate"). Clearing the token also re-gates the submit button until
+  // the fresh one arrives.
+  const resetCaptcha = () => {
+    turnstileRef.current?.reset();
+    setCaptchaToken(null);
+  };
 
   const { push } = useRouter();
 
@@ -104,10 +114,22 @@ export default function AuthForm({ mode }: { mode: Mode }) {
           },
         });
         if (error) throw error;
+
+        // Anti-enumeration: for an already-registered email Supabase returns a
+        // session-less user with an EMPTY identities array (and sends no email).
+        // Without this check we'd wrongly show the "check your email" screen for an
+        // account that already exists.
+        if (data.user && data.user.identities && data.user.identities.length === 0) {
+          errorToast('An account with this email already exists — try logging in instead.');
+          resetCaptcha();
+          setSubmitting(false);
+          submittingRef.current = false;
+          return;
+        }
+
         toast.dismiss('auth-error');
         // With email confirmation on, signUp returns no session until the email is
-        // verified (via the link or the code below). A session-less user is also
-        // returned for an already-registered email, avoiding account enumeration.
+        // verified (via the link or the code below).
         if (!data.session) {
           setCheckEmail(true);
           setSubmitting(false);
@@ -119,6 +141,7 @@ export default function AuthForm({ mode }: { mode: Mode }) {
       }
     } catch (err) {
       errorToast(err instanceof Error ? err.message : 'Something went wrong.');
+      resetCaptcha();
       submittingRef.current = false;
       setSubmitting(false);
     }
@@ -301,6 +324,7 @@ export default function AuthForm({ mode }: { mode: Mode }) {
                   </div>
 
                   <TurnstileWidget
+                    ref={turnstileRef}
                     onVerify={setCaptchaToken}
                     onExpire={() => setCaptchaToken(null)}
                   />

--- a/website/components/auth/AuthHashErrorHandler.tsx
+++ b/website/components/auth/AuthHashErrorHandler.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { useEffect } from 'react';
+import { toast } from 'sonner';
+
+// Supabase (and OAuth) can redirect to the site with an error in the URL *hash*, e.g.
+//   https://cccsolutions.ca/#error=access_denied&error_code=otp_expired&error_description=...
+// Nothing else reads the hash, so without this the user just lands on a broken-looking
+// URL with no feedback. This runs once globally, surfaces a friendly message, and clears
+// the hash so a refresh doesn't re-trigger it. (New email links go through /auth/confirm,
+// which handles its own errors; this is the catch-all for stray/legacy error redirects.)
+export function AuthHashErrorHandler() {
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.location.hash) return;
+
+    const params = new URLSearchParams(window.location.hash.slice(1));
+    const errorCode = params.get('error_code');
+    const error = params.get('error');
+    if (!errorCode && !error) return;
+
+    const message =
+      errorCode === 'otp_expired'
+        ? 'That link expired or was already used. Request a new email, or enter the 6-digit code from it.'
+        : (params.get('error_description')?.replace(/\+/g, ' ') ??
+          'Something went wrong with that link.');
+
+    toast.error(message, { id: 'auth-hash-error', duration: 8000 });
+
+    // Strip the hash so a refresh doesn't re-fire this and the URL reads clean.
+    window.history.replaceState(null, '', window.location.pathname + window.location.search);
+  }, []);
+
+  return null;
+}

--- a/website/components/auth/TurnstileWidget.tsx
+++ b/website/components/auth/TurnstileWidget.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
+import { forwardRef, useEffect, useImperativeHandle, useRef } from 'react';
 
 declare global {
   interface Window {
@@ -38,6 +38,8 @@ function loadTurnstileScript(): Promise<void> {
   return scriptLoadPromise;
 }
 
+export type TurnstileHandle = { reset: () => void };
+
 type Props = {
   onVerify: (token: string) => void;
   onExpire?: () => void;
@@ -46,11 +48,25 @@ type Props = {
 
 // Cloudflare Turnstile widget. Renders nothing (and reports no token) if the
 // site key isn't configured, so auth still works locally without it wired up.
-export function TurnstileWidget({ onVerify, onExpire, theme = 'auto' }: Props) {
+// Exposes reset() via ref: a Turnstile token is single-use, so after a failed
+// submit the form must reset the widget for a fresh token — reusing the spent one
+// makes the next attempt fail with "timeout-or-duplicate".
+export const TurnstileWidget = forwardRef<TurnstileHandle, Props>(function TurnstileWidget(
+  { onVerify, onExpire, theme = 'auto' },
+  ref
+) {
   const containerRef = useRef<HTMLDivElement>(null);
   const widgetIdRef = useRef<string | null>(null);
 
   const siteKey = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY;
+
+  useImperativeHandle(ref, () => ({
+    reset: () => {
+      if (widgetIdRef.current && window.turnstile) {
+        window.turnstile.reset(widgetIdRef.current);
+      }
+    },
+  }));
 
   useEffect(() => {
     if (!siteKey || !containerRef.current) return;
@@ -83,4 +99,4 @@ export function TurnstileWidget({ onVerify, onExpire, theme = 'auto' }: Props) {
   if (!siteKey) return null;
 
   return <div ref={containerRef} className="flex justify-center" />;
-}
+});

--- a/website/components/layout/Providers.tsx
+++ b/website/components/layout/Providers.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import { ThemeProvider as NextThemesProvider, useTheme } from 'next-themes';
 import { Toaster } from 'sonner';
 import { SupabaseAuthProvider } from '../auth/SupabaseAuthProvider';
+import { AuthHashErrorHandler } from '../auth/AuthHashErrorHandler';
 
 // Sonner reads its own theme prop, so sync it to next-themes rather than letting
 // it fall back to prefers-color-scheme (which ignores the in-app theme toggle).
@@ -31,6 +32,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
     >
       <SupabaseAuthProvider>
         {children}
+        <AuthHashErrorHandler />
         <ThemedToaster />
       </SupabaseAuthProvider>
     </NextThemesProvider>


### PR DESCRIPTION
## Description

Four auth-flow bugs surfaced while debugging signup/confirmation. All fixes are frontend, plus **one dashboard email-template edit** (below) to point confirmation links at the new page.

### 1. Email confirmation links die on school/corporate inboxes (`otp_expired`)
`@uwaterloo.ca` and other Microsoft/Outlook inboxes run **Safe Links**, which pre-fetches every URL in an email. Supabase's `/auth/v1/verify` **consumes the token on a raw GET**, so the scanner burns it before the user clicks — confirmed in the auth logs (`GET /auth/v1/verify` fired **twice with the same token**). New **`/auth/confirm`** page runs `verifyOtp` in **client-side JS**, which scanners GET but don't execute, so the token survives the prescan and is only spent when a real browser loads. Type-aware routing (`signup` → `/forum`, `recovery` → `/update-password`), so the confirm-signup **and** reset-password templates share it. The 6-digit code stays as the fallback for the rare JS-executing scanner.

### 2. Turnstile "timeout-or-duplicate" after a failed login
A Turnstile token is single-use, but the widget was never reset after a failed submit, so the next attempt reused the spent token. The widget now exposes `reset()` via ref; the form resets it after any failed/duplicate submit and re-gates the button until a fresh token arrives.

### 3. Duplicate-email signup showed fake success
Signing up with an already-registered email showed "check your email" even though Supabase (correctly, anti-enumeration) sends nothing. Now detected via the **empty `identities` array** → "an account with this email already exists — log in instead."

### 4. No handler for expired/consumed links
Nothing read the `#error=otp_expired` hash Supabase redirects with, leaving users on a broken URL. A global `AuthHashErrorHandler` surfaces a friendly message + clears the hash; `/auth/confirm` shows its own expired state pointing to the code.

## Changes
- **`app/auth/confirm/page.tsx`** (new) — generic verify-on-load page, type-aware routing, expired/error state.
- **`components/auth/TurnstileWidget.tsx`** — `forwardRef` + `reset()` handle.
- **`components/auth/AuthForm.tsx`** — `identities` dup-email check; reset captcha after failed/duplicate submit.
- **`components/auth/AuthHashErrorHandler.tsx`** (new) + **`Providers.tsx`** — global `#error=` catch-all.

## Required dashboard edit (not code)
In **Auth → Email Templates**, change the link `{{ .ConfirmationURL }}` → `{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=signup` in **Confirm signup**, and `...&type=recovery` in **Reset password**. Keep the `{{ .Token }}` code line. (Magic-link / change-email templates are unused; when enabled, point them at `/auth/confirm?type=<x>` too — the page already handles it.)

## Testing
- `tsc` + `eslint` clean.
- Manual smoke-test plan to follow (signup link + code, dup email, reset, expired link, captcha retry).

## Linked issues
Refs #

## Checklist
- [x] Gave my own code a once-over
- [x] `tsc` + lint pass locally
- [ ] Tests — N/A (auth UI; covered by the manual smoke plan)
- [x] Formatted / matches style
- [x] Docs/comments updated (inline rationale on each fix)