### PR TITLE
fix(auth): confirm-page copy, #error toast, and redirect when already logged in

### DIFF
--- a/website/app/auth/confirm/page.tsx
+++ b/website/app/auth/confirm/page.tsx
@@ -76,25 +76,19 @@ function ConfirmHandler() {
     );
   }
 
-  // The link expired, was already used, or was consumed by an email scanner. Point the
-  // user at the 6-digit code, which never has this problem.
-  const codeHref = type === 'recovery' ? '/reset-password' : '/signup';
+  // The link expired, was already used, or was opened by an email scanner. Send the user
+  // back to log in; the 6-digit code from the same email still works if they need it.
   return (
     <Centered>
       <h1 className="text-2xl font-semibold tracking-tight mb-3">This link didn&apos;t work</h1>
       <p className="text-foreground-light mb-6">
-        It may have expired, already been used, or been pre-scanned by your email provider. Enter
-        the <span className="text-foreground font-medium">6-digit code</span> from the same email
-        instead, or request a new one.
+        It may have expired, already been used, or been opened by your email&apos;s security
+        scanner. Request a new email, or use the{' '}
+        <span className="text-foreground font-medium">6-digit code</span> from it.
       </p>
-      <div className="flex justify-center gap-3">
-        <Button asChild type="primary" size="medium">
-          <Link href={codeHref}>Enter the code</Link>
-        </Button>
-        <Button asChild type="default" size="medium">
-          <Link href="/login">Back to login</Link>
-        </Button>
-      </div>
+      <Button asChild type="primary" size="medium">
+        <Link href="/login">Back to login</Link>
+      </Button>
     </Centered>
   );
 }

--- a/website/components/auth/AuthForm.tsx
+++ b/website/components/auth/AuthForm.tsx
@@ -9,6 +9,7 @@ import { FlickeringGrid } from '../effects/FlickeringGrid';
 import { Button } from '../ui/button';
 import { Card, CardContent } from '../ui/card';
 import { TurnstileWidget, type TurnstileHandle } from './TurnstileWidget';
+import { useAuth } from './SupabaseAuthProvider';
 
 const inputClass =
   'w-full h-10 px-3 rounded-md border border-border-strong bg-surface-100 text-sm text-foreground placeholder:text-foreground-lighter focus:outline-none focus:border-brand-highlight';
@@ -67,6 +68,12 @@ export default function AuthForm({ mode }: { mode: Mode }) {
   };
 
   const { push } = useRouter();
+  const { state } = useAuth();
+
+  // Already signed in? The login/signup pages shouldn't be usable — bounce to the forum.
+  useEffect(() => {
+    if (state === 'in') push('/forum');
+  }, [state, push]);
 
   // Surface OAuth-callback failures (which redirect here as ?error=...) as a toast.
   useEffect(() => {
@@ -174,6 +181,9 @@ export default function AuthForm({ mode }: { mode: Mode }) {
     });
     if (error) errorToast(error.message);
   };
+
+  // Don't flash the form to an already-signed-in user while the redirect above runs.
+  if (state === 'in') return null;
 
   return (
     <div className="relative min-h-[calc(100svh-var(--nav-h))] flex flex-col justify-center items-center px-4 bg-background overflow-hidden">

--- a/website/components/auth/AuthHashErrorHandler.tsx
+++ b/website/components/auth/AuthHashErrorHandler.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect } from 'react';
 import { toast } from 'sonner';
+import { initialAuthErrorHash } from '../../lib/supabase';
 
 // Supabase (and OAuth) can redirect to the site with an error in the URL *hash*, e.g.
 //   https://cccsolutions.ca/#error=access_denied&error_code=otp_expired&error_description=...
@@ -11,9 +12,10 @@ import { toast } from 'sonner';
 // which handles its own errors; this is the catch-all for stray/legacy error redirects.)
 export function AuthHashErrorHandler() {
   useEffect(() => {
-    if (typeof window === 'undefined' || !window.location.hash) return;
+    // Captured at module load in lib/supabase.ts, before supabase-js strips the hash.
+    if (!initialAuthErrorHash) return;
 
-    const params = new URLSearchParams(window.location.hash.slice(1));
+    const params = new URLSearchParams(initialAuthErrorHash);
     const errorCode = params.get('error_code');
     const error = params.get('error');
     if (!errorCode && !error) return;
@@ -26,8 +28,7 @@ export function AuthHashErrorHandler() {
 
     toast.error(message, { id: 'auth-hash-error', duration: 8000 });
 
-    // Strip the hash so a refresh doesn't re-fire this and the URL reads clean.
-    window.history.replaceState(null, '', window.location.pathname + window.location.search);
+    // supabase-js already cleaned the hash off the URL; nothing left to strip here.
   }, []);
 
   return null;

--- a/website/lib/supabase.ts
+++ b/website/lib/supabase.ts
@@ -17,6 +17,15 @@ if (!supabaseUrl || !supabasePublishableKey) {
   );
 }
 
+// supabase-js (detectSessionInUrl, on by default) consumes and clears the URL hash on
+// init — including error params like #error=otp_expired — before any React effect runs.
+// Capture it here, synchronously and ahead of createClient, so AuthHashErrorHandler can
+// still surface it instead of the user silently landing on a clean page.
+export const initialAuthErrorHash =
+  typeof window !== 'undefined' && window.location.hash.includes('error=')
+    ? window.location.hash.slice(1)
+    : '';
+
 export const supabase = createClient(supabaseUrl, supabasePublishableKey);
 
 /** Returns the current session's access_token (JWT) or null if not logged in. */


### PR DESCRIPTION
Follow-up to #217. The expired/failed state on `/auth/confirm` had two buttons and copy that wrapped awkwardly ("pre-scanned" broke across a line). Now a single **Back to login** action, reworded to "opened by your email's security scanner" so nothing hyphen-wraps. The 6-digit code is still mentioned as the fallback.

## Checklist
- [x] tsc + lint + format pass locally