### PR TITLE
fix(website): fetch GitHub star count at build time (fix stale/blank count)

### DIFF
--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -20,28 +20,23 @@ import { stats } from '../constants';
 import { kFormatter } from '../lib/utils';
 import { SolutionPreview } from '../components/solutions/SolutionPreview';
 
-// Shown if the build-time fetch is unavailable; bump when the real count moves a lot.
-const FALLBACK_GITHUB_STARS = 9;
-
-async function getGithubStars(): Promise<number> {
+async function getGithubStars(): Promise<number | null> {
   try {
     const res = await fetch('https://api.github.com/repos/CCCSolutions/CCCSolutions', {
-      // Bake at build time (force-cache), not per-request. GitHub's unauthenticated API is
-      // 60/hr *per IP*, and both hosts share egress IPs (Workers especially), so a runtime
-      // fetch gets throttled — and that failure would blank the count (v2) or freeze the
-      // last cached value forever (Netlify). Fetching once per build sidesteps the shared-IP
-      // throttle; the number refreshes on every deploy, and the fallback means it never
-      // blanks even if the build fetch itself is throttled.
+      // Baked at build time (force-cache), not per-request. GitHub's unauthenticated API is
+      // 60/hr *per IP* and both hosts share egress IPs (Workers especially), so a runtime
+      // fetch gets throttled — which froze the last cached value (Netlify) or blanked it (v2).
+      // Fetching once per build sidesteps the shared-IP throttle and refreshes on deploy. If
+      // the build fetch is itself throttled, return null and hide the count (never fake it) —
+      // see the tracking issue; the real fix is an authenticated + cached backend route.
       cache: 'force-cache',
       headers: { Accept: 'application/vnd.github+json' },
     });
-    if (!res.ok) return FALLBACK_GITHUB_STARS;
+    if (!res.ok) return null;
     const data = await res.json();
-    return typeof data.stargazers_count === 'number'
-      ? data.stargazers_count
-      : FALLBACK_GITHUB_STARS;
+    return typeof data.stargazers_count === 'number' ? data.stargazers_count : null;
   } catch {
-    return FALLBACK_GITHUB_STARS;
+    return null;
   }
 }
 
@@ -250,8 +245,12 @@ const Home = async () => {
                 >
                   <GitHubLogoIcon width="18" height="18" />
                   <span>cccsolutions</span>
-                  <span className="text-foreground-muted px-1">|</span>
-                  <span>{kFormatter(githubStars)}</span>
+                  {githubStars !== null && (
+                    <>
+                      <span className="text-foreground-muted px-1">|</span>
+                      <span>{kFormatter(githubStars)}</span>
+                    </>
+                  )}
                 </a>
               </Button>
             </div>

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -20,17 +20,28 @@ import { stats } from '../constants';
 import { kFormatter } from '../lib/utils';
 import { SolutionPreview } from '../components/solutions/SolutionPreview';
 
-async function getGithubStars(): Promise<number | null> {
+// Shown if the build-time fetch is unavailable; bump when the real count moves a lot.
+const FALLBACK_GITHUB_STARS = 9;
+
+async function getGithubStars(): Promise<number> {
   try {
     const res = await fetch('https://api.github.com/repos/CCCSolutions/CCCSolutions', {
-      next: { revalidate: 86400 },
+      // Bake at build time (force-cache), not per-request. GitHub's unauthenticated API is
+      // 60/hr *per IP*, and both hosts share egress IPs (Workers especially), so a runtime
+      // fetch gets throttled — and that failure would blank the count (v2) or freeze the
+      // last cached value forever (Netlify). Fetching once per build sidesteps the shared-IP
+      // throttle; the number refreshes on every deploy, and the fallback means it never
+      // blanks even if the build fetch itself is throttled.
+      cache: 'force-cache',
       headers: { Accept: 'application/vnd.github+json' },
     });
-    if (!res.ok) return null;
+    if (!res.ok) return FALLBACK_GITHUB_STARS;
     const data = await res.json();
-    return typeof data.stargazers_count === 'number' ? data.stargazers_count : null;
+    return typeof data.stargazers_count === 'number'
+      ? data.stargazers_count
+      : FALLBACK_GITHUB_STARS;
   } catch {
-    return null;
+    return FALLBACK_GITHUB_STARS;
   }
 }
 
@@ -239,12 +250,8 @@ const Home = async () => {
                 >
                   <GitHubLogoIcon width="18" height="18" />
                   <span>cccsolutions</span>
-                  {githubStars !== null && (
-                    <>
-                      <span className="text-foreground-muted px-1">|</span>
-                      <span>{kFormatter(githubStars)}</span>
-                    </>
-                  )}
+                  <span className="text-foreground-muted px-1">|</span>
+                  <span>{kFormatter(githubStars)}</span>
                 </a>
               </Button>
             </div>

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -23,12 +23,10 @@ import { SolutionPreview } from '../components/solutions/SolutionPreview';
 async function getGithubStars(): Promise<number | null> {
   try {
     const res = await fetch('https://api.github.com/repos/CCCSolutions/CCCSolutions', {
-      // Baked at build time (force-cache), not per-request. GitHub's unauthenticated API is
-      // 60/hr *per IP* and both hosts share egress IPs (Workers especially), so a runtime
-      // fetch gets throttled — which froze the last cached value (Netlify) or blanked it (v2).
-      // Fetching once per build sidesteps the shared-IP throttle and refreshes on deploy. If
-      // the build fetch is itself throttled, return null and hide the count (never fake it) —
-      // see the tracking issue; the real fix is an authenticated + cached backend route.
+      // Baked at build time (force-cache) rather than per-request. GitHub's unauthenticated API is too low and both hosts 
+      // share egress IPs so a runtime fetch gets throttled. Fetching once per build sidesteps the shared-IP throttle and 
+      // refreshes on deploy. If the build fetch is itself throttled/fails, return null and hide the count
+      // TODO: see the tracking issue and fix it with an authenticated endpoint 
       cache: 'force-cache',
       headers: { Accept: 'application/vnd.github+json' },
     });


### PR DESCRIPTION
## Description

The homepage GitHub star count was wrong on both domains: **cccsolutions.ca (Netlify)** showed a frozen `7` (actual is 9), and **v2.cccsolutions.ca (Workers)** showed **nothing**.

Same root cause: `getGithubStars` fetched `api.github.com` **per request** (`next: { revalidate: 86400 }`). GitHub's unauthenticated API is **60/hr per IP**, and both hosts make outbound calls from **shared egress IPs** (Workers especially), so the fetch gets `403`-throttled by unrelated traffic on the same IP. On Netlify that froze the last cached `7`; on Workers it returned `null` and the render hid the number.

## Changes

- `website/app/page.tsx`: fetch the count with `cache: 'force-cache'` so it's **baked once at build**, not per request — this sidesteps the shared-IP runtime throttle and refreshes on every deploy.
- On failure it returns `null` and the count is **hidden** — deliberately no hardcoded fallback (never show a fake number). The residual risk (a throttled *build* fetch blanks the count) is tracked separately.

## Testing

- `tsc`, `eslint`, and `prettier@3.9.4 --check .` all clean locally.
- Confirmed the truth via `api.github.com` = 9, and reproduced both stale/blank symptoms via curl on the two domains.

## Linked issues

Refs #223

## Checklist

- [x] I read CONTRIBUTING.md and gave my own code a once-over (it runs and does what the PR says)
- [x] `tsc`, lint, and tests pass locally (CI checks these too)
- [ ] New backend feature code (`backend/src/`) has vitest tests — N/A (frontend, no new logic)
- [x] Code is formatted and matches the surrounding style (CI checks this)
- [x] Docs/comments updated if behavior or APIs changed