### PR TITLE
style(website): fix prettier CI on main (trailing whitespace in page.tsx)

### DIFF
--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -23,10 +23,10 @@ import { SolutionPreview } from '../components/solutions/SolutionPreview';
 async function getGithubStars(): Promise<number | null> {
   try {
     const res = await fetch('https://api.github.com/repos/CCCSolutions/CCCSolutions', {
-      // Baked at build time (force-cache) rather than per-request. GitHub's unauthenticated API is too low and both hosts 
-      // share egress IPs so a runtime fetch gets throttled. Fetching once per build sidesteps the shared-IP throttle and 
+      // Baked at build time (force-cache) rather than per-request. GitHub's unauthenticated API is too low and both hosts
+      // share egress IPs so a runtime fetch gets throttled. Fetching once per build sidesteps the shared-IP throttle and
       // refreshes on deploy. If the build fetch is itself throttled/fails, return null and hide the count
-      // TODO: see the tracking issue and fix it with an authenticated endpoint 
+      // TODO: see the tracking issue and fix it with an authenticated endpoint
       cache: 'force-cache',
       headers: { Accept: 'application/vnd.github+json' },
     });


### PR DESCRIPTION
## Description

`main`'s CI is red — the `website` job fails `prettier --check` (v3.9.4) on `app/page.tsx`: three comment lines in `getGithubStars` have trailing whitespace. Comment wording is unchanged; this only strips the trailing spaces.

## Changes

- `website/app/page.tsx` — `prettier --write` (removed trailing whitespace on 3 lines).

## Testing

- `prettier@3.9.4 --check` (the exact CI version) passes.

## Linked issues

Refs #223

## Checklist

- [x] `tsc`, lint, and format pass locally
- [x] Code is formatted and matches the surrounding style