### PR TITLE
fix(website): log GitHub stars fetch failure (+ fix prettier CI)

### DIFF
--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -23,17 +23,23 @@ import { SolutionPreview } from '../components/solutions/SolutionPreview';
 async function getGithubStars(): Promise<number | null> {
   try {
     const res = await fetch('https://api.github.com/repos/CCCSolutions/CCCSolutions', {
-      // Baked at build time (force-cache) rather than per-request. GitHub's unauthenticated API is too low and both hosts 
-      // share egress IPs so a runtime fetch gets throttled. Fetching once per build sidesteps the shared-IP throttle and 
+      // Baked at build time (force-cache) rather than per-request. GitHub's unauthenticated API is too low and both hosts
+      // share egress IPs so a runtime fetch gets throttled. Fetching once per build sidesteps the shared-IP throttle and
       // refreshes on deploy. If the build fetch is itself throttled/fails, return null and hide the count
-      // TODO: see the tracking issue and fix it with an authenticated endpoint 
+      // TODO: see the tracking issue and fix it with an authenticated endpoint
       cache: 'force-cache',
       headers: { Accept: 'application/vnd.github+json' },
     });
-    if (!res.ok) return null;
+    if (!res.ok) {
+      // Logged so the build output shows the real cause (e.g. 403 rate-limit) instead of
+      // silently baking a blank count. See the tracking issue.
+      console.warn(`[github-stars] fetch failed: ${res.status} ${res.statusText}`);
+      return null;
+    }
     const data = await res.json();
     return typeof data.stargazers_count === 'number' ? data.stargazers_count : null;
-  } catch {
+  } catch (err) {
+    console.warn('[github-stars] fetch threw:', err);
     return null;
   }
 }


### PR DESCRIPTION
## Description

Two things in one small change to `getGithubStars`:

1. The build-time GitHub fetch fails silently (`if (!res.ok) return null` and a bare `catch`), so when the star count comes back blank (currently on v2) there is no way to know why. This adds a `console.warn` on both failure paths, so the next build log shows the real status (e.g. `403` rate-limit) or thrown error.
2. Fixes the prettier CI failure on main (trailing whitespace on the comment lines). Supersedes #224, which was the whitespace-only fix.

## Changes

- `website/app/page.tsx`:
  - `console.warn('[github-stars] fetch failed: <status> <statusText>')` on `!res.ok`.
  - `console.warn('[github-stars] fetch threw:', err)` in `catch`.
  - Trailing whitespace removed (prettier 3.9.4).

## Testing

- `prettier@3.9.4 --check`, `tsc`, and `eslint` all pass locally.
- Behavior unchanged for the happy path; failures still return `null` and hide the count, now with a log line.

## Linked issues

Refs #223. Supersedes #224.

## Checklist

- [x] tsc, lint, and format pass locally
- [x] Code is formatted and matches the surrounding style