### PR TITLE
fix(backend): alert on cache purge failures

### DIFF
--- a/backend/src/admin/routes.ts
+++ b/backend/src/admin/routes.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono';
 import type { Context } from 'hono';
 import type { Bindings } from '../types';
 import { problemParamsSchema, fileSchema } from '../r2/validation';
+import { purgeCacheTags } from '../cache';
 
 const admin = new Hono<{ Bindings: Bindings }>();
 
@@ -30,10 +31,7 @@ admin.use('*', async (c, next) => {
 // cached /list + /preview go stale. Workers Cache tag-purge (GA 2026-07-06),
 // fire-and-forget via waitUntil.
 function purgeContest(c: Context<{ Bindings: Bindings }>, year: string, code: string): void {
-  // Cast to the Cloudflare runtime shape; Hono's ExecutionContext type lacks .cache.
-  const ctx = c.executionCtx as unknown as ExecutionContext;
-  if (!ctx.cache) return;
-  ctx.waitUntil(ctx.cache.purge({ tags: [`contest:${year}:${code}`] }));
+  purgeCacheTags(c, [`contest:${year}:${code}`], `contest ${year}/${code}`);
 }
 
 admin.post('/contests/:year/:code/upload', async (c) => {

--- a/backend/src/cache.ts
+++ b/backend/src/cache.ts
@@ -19,8 +19,8 @@ async function reportPurgeFailure(env: Bindings, scope: string, tags: string[], 
 // so Cloudflare keeps the invocation alive for the Discord alert too.
 export function purgeCacheTags<E extends { Bindings: Bindings }>(c: Context<E>, tags: string[], scope: string): void {
   // Hono's ExecutionContext type has not added Workers Cache's .cache yet.
-  const ctx = c.executionCtx as CacheExecutionContext;
-  const cache = ctx.cache;
+  const executionCtx = c.executionCtx as CacheExecutionContext;
+  const cache = executionCtx.cache;
   if (!cache) return;
 
   const purgeAndReport = (async () => {
@@ -38,5 +38,5 @@ export function purgeCacheTags<E extends { Bindings: Bindings }>(c: Context<E>, 
     }
   })();
 
-  ctx.waitUntil(purgeAndReport);
+  executionCtx.waitUntil(purgeAndReport);
 }

--- a/backend/src/cache.ts
+++ b/backend/src/cache.ts
@@ -1,0 +1,42 @@
+import type { Context, ExecutionContext as HonoExecutionContext } from 'hono';
+import { send } from './notify';
+import type { Bindings } from './types';
+
+type CacheExecutionContext = HonoExecutionContext & Pick<ExecutionContext, 'cache'>;
+
+async function reportPurgeFailure(env: Bindings, scope: string, tags: string[], failure: string): Promise<void> {
+  console.error('workers cache purge failed', { scope, tags, failure });
+  await send(env, {
+    kind: 'alert',
+    title: 'Workers cache purge failed',
+    description: [`Scope: ${scope}`, `Tags: ${tags.join(', ')}`, `Failure: ${failure}`].join('\n'),
+    ping: true,
+  });
+}
+
+// Purging is deliberately post-response: a failed purge must not turn a committed
+// DB/R2 write into an apparent 500. The same waitUntil task owns failure reporting,
+// so Cloudflare keeps the invocation alive for the Discord alert too.
+export function purgeCacheTags<E extends { Bindings: Bindings }>(c: Context<E>, tags: string[], scope: string): void {
+  // Hono's ExecutionContext type has not added Workers Cache's .cache yet.
+  const ctx = c.executionCtx as CacheExecutionContext;
+  const cache = ctx.cache;
+  if (!cache) return;
+
+  const purgeAndReport = (async () => {
+    try {
+      const result = await cache.purge({ tags });
+      if (result.success) return;
+
+      const failure = result.errors.length
+        ? result.errors.map((error) => `${error.code}: ${error.message}`).join('\n')
+        : 'Cache API returned success=false without details.';
+      await reportPurgeFailure(c.env, scope, tags, failure);
+    } catch (error) {
+      const failure = error instanceof Error ? `${error.name}: ${error.message}` : String(error);
+      await reportPurgeFailure(c.env, scope, tags, failure);
+    }
+  })();
+
+  ctx.waitUntil(purgeAndReport);
+}

--- a/backend/src/forum/routes.ts
+++ b/backend/src/forum/routes.ts
@@ -7,6 +7,7 @@ import { requireAuth, type AuthVars } from '../middleware/auth';
 import { createPostSchema, createCommentSchema, voteSchema, unvoteSchema } from './validation';
 import { resolvePageSize, resolveOffset } from './pagination';
 import { notify } from '../notify';
+import { purgeCacheTags } from '../cache';
 
 const forum = new Hono<{ Bindings: Bindings; Variables: AuthVars }>();
 
@@ -30,9 +31,7 @@ const commentScore = sql<number>`coalesce((select sum(${votes.value})::int from 
 const FORUM_CACHE = 'public, max-age=0, s-maxage=30';
 
 function purgeForum(c: Context<{ Bindings: Bindings; Variables: AuthVars }>): void {
-  const ctx = c.executionCtx as unknown as ExecutionContext;
-  if (!ctx.cache) return;
-  ctx.waitUntil(ctx.cache.purge({ tags: ['forum-posts'] }));
+  purgeCacheTags(c, ['forum-posts'], 'forum');
 }
 
 forum.get('/posts', async (c) => {

--- a/backend/src/notify.ts
+++ b/backend/src/notify.ts
@@ -3,7 +3,7 @@
 import type { Context } from 'hono';
 import type { Bindings } from './types';
 
-const COLORS = { post: 0x5865f2, comment: 0x57f287, digest: 0x9b59b6 } as const;
+const COLORS = { post: 0x5865f2, comment: 0x57f287, digest: 0x9b59b6, alert: 0xed4245 } as const;
 
 export type NotifyEvent = {
   kind: keyof typeof COLORS;

--- a/backend/test/cache.test.ts
+++ b/backend/test/cache.test.ts
@@ -1,0 +1,109 @@
+import type { Context } from 'hono';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { purgeCacheTags } from '../src/cache';
+import type { Bindings } from '../src/types';
+
+const env = {
+  DISCORD_WEBHOOK_URL: 'https://discord.com/api/webhooks/1/token',
+  FRONTEND_URL: 'https://cccsolutions.ca',
+} as Bindings;
+
+type PurgeResult = { success: boolean; errors: { code: number; message: string }[] };
+
+function testContext(purge?: (options: { tags?: string[] }) => Promise<PurgeResult>) {
+  const backgroundTasks: Promise<unknown>[] = [];
+  const executionCtx = {
+    cache: purge ? { purge } : undefined,
+    waitUntil: vi.fn((promise: Promise<unknown>) => {
+      backgroundTasks.push(promise);
+    }),
+    passThroughOnException: vi.fn(),
+    props: {},
+  };
+  const c = { env, executionCtx } as unknown as Context<{ Bindings: Bindings }>;
+
+  return {
+    c,
+    executionCtx,
+    async settle() {
+      await Promise.all(backgroundTasks);
+    },
+  };
+}
+
+function webhookBody(fetchMock: ReturnType<typeof vi.fn>) {
+  return JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string);
+}
+
+beforeEach(() => {
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('purgeCacheTags', () => {
+  it('purges in waitUntil and stays silent on success', async () => {
+    const purge = vi.fn(async () => ({ success: true, errors: [] }));
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    const { c, executionCtx, settle } = testContext(purge);
+
+    purgeCacheTags(c, ['forum-posts'], 'forum');
+    await settle();
+
+    expect(executionCtx.waitUntil).toHaveBeenCalledOnce();
+    expect(purge).toHaveBeenCalledWith({ tags: ['forum-posts'] });
+    expect(console.error).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('logs and sends a Discord alert when the Cache API reports failure', async () => {
+    const purge = vi.fn(async () => ({ success: false, errors: [{ code: 1001, message: 'unavailable' }] }));
+    const fetchMock = vi.fn(async () => new Response('{}', { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+    const { c, settle } = testContext(purge);
+
+    purgeCacheTags(c, ['forum-posts'], 'forum');
+    await settle();
+
+    expect(console.error).toHaveBeenCalledWith('workers cache purge failed', {
+      scope: 'forum',
+      tags: ['forum-posts'],
+      failure: '1001: unavailable',
+    });
+    const body = webhookBody(fetchMock);
+    expect(body.content).toBe('@everyone');
+    expect(body.embeds[0].title).toBe('Workers cache purge failed');
+    expect(body.embeds[0].description).toContain('Tags: forum-posts');
+  });
+
+  it('logs and alerts when cache.purge rejects', async () => {
+    const purge = vi.fn(async (): Promise<PurgeResult> => {
+      throw new Error('connection reset');
+    });
+    const fetchMock = vi.fn(async () => new Response('{}', { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+    const { c, settle } = testContext(purge);
+
+    purgeCacheTags(c, ['contest:2024:s1'], 'contest 2024/s1');
+    await settle();
+
+    expect(console.error).toHaveBeenCalledWith('workers cache purge failed', {
+      scope: 'contest 2024/s1',
+      tags: ['contest:2024:s1'],
+      failure: 'Error: connection reset',
+    });
+    expect(webhookBody(fetchMock).embeds[0].description).toContain('Scope: contest 2024/s1');
+  });
+
+  it('does nothing when the runtime has no Workers Cache context', () => {
+    const { c, executionCtx } = testContext();
+
+    purgeCacheTags(c, ['forum-posts'], 'forum');
+
+    expect(executionCtx.waitUntil).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Description

Workers Cache purges run after write responses through `waitUntil()`. Failures were previously invisible, which could leave forum reads or contest listings temporarily stale with no operational signal. This centralizes cache purging and reports failures without turning an already-committed DB or R2 write into an apparent request failure.

## Changes

- Add a shared `purgeCacheTags()` helper for forum and contest cache invalidation.
- Log structured purge failures to Cloudflare Logs.
- Send a red `@everyone` alert through the existing `DISCORD_WEBHOOK_URL` when the Cache API reports failure or rejects.
- Keep the purge and any failure alert inside the same `waitUntil()` task.
- Add Vitest coverage for successful purges, API-declared failures, rejected promises, and runtimes without Workers Cache context.

## Testing

- `bun run test` — 56 passed, 2 todo.
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`

## Linked issues

None.

## Checklist

- [x] I read CONTRIBUTING.md and gave my own code a once-over (it runs and does what the PR says)
- [x] `tsc`, lint, and tests pass locally (CI checks these too)
- [x] New backend feature code (`backend/src/`) has vitest tests
- [x] Code is formatted and matches the surrounding style (CI checks this)
- [x] Docs/comments updated if behavior or APIs changed
