### PR TITLE
feat(forum): pinned posts (admin-only pin + column lock + badge UI)

### DIFF
--- a/backend/drizzle/0003_sparkling_layla_miller.sql
+++ b/backend/drizzle/0003_sparkling_layla_miller.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "posts" ADD COLUMN "is_pinned" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE "posts" ADD COLUMN "pinned_at" timestamp with time zone DEFAULT now() NOT NULL;

--- a/backend/drizzle/0004_lock_is_pinned_column.sql
+++ b/backend/drizzle/0004_lock_is_pinned_column.sql
@@ -1,0 +1,8 @@
+-- is_pinned is admin-only. Pinning goes through the privileged pooler role (plain getDb in
+-- POST /forum/posts/:id/pin, gated by an admin role check in the endpoint), never the
+-- `authenticated` / withUser path. Postgres cannot exclude one column from a table-wide
+-- UPDATE grant, so we drop the table-wide UPDATE that 0002 gave `authenticated` and re-grant
+-- UPDATE only on the columns an author may edit. Result: no normal user can change is_pinned
+-- (or pinned_at) on any post, including their own, regardless of endpoint or RLS.
+REVOKE UPDATE ON "posts" FROM authenticated;--> statement-breakpoint
+GRANT UPDATE ("title", "content") ON "posts" TO authenticated;

--- a/backend/drizzle/meta/0003_snapshot.json
+++ b/backend/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,512 @@
+{
+  "id": "b2da2696-a6f4-4956-b9a7-2c0e88f6bd53",
+  "prevId": "9cf6a364-7442-4f6f-aed1-7cdb8b4ca762",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.comments": {
+      "name": "comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "comments_post_id_posts_id_fk": {
+          "name": "comments_post_id_posts_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "comments_profile_id_profiles_id_fk": {
+          "name": "comments_profile_id_profiles_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "comments_select_all": {
+          "name": "comments_select_all",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "public"
+          ],
+          "using": "true"
+        },
+        "comments_insert_self": {
+          "name": "comments_insert_self",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\"comments\".\"profile_id\" = (select id from profiles where auth_user_id = (select auth.uid()))"
+        },
+        "comments_update_self": {
+          "name": "comments_update_self",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\"comments\".\"profile_id\" = (select id from profiles where auth_user_id = (select auth.uid()))",
+          "withCheck": "\"comments\".\"profile_id\" = (select id from profiles where auth_user_id = (select auth.uid()))"
+        },
+        "comments_delete_self": {
+          "name": "comments_delete_self",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\"comments\".\"profile_id\" = (select id from profiles where auth_user_id = (select auth.uid()))"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posts": {
+      "name": "posts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_pinned": {
+          "name": "is_pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "pinned_at": {
+          "name": "pinned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "posts_profile_id_profiles_id_fk": {
+          "name": "posts_profile_id_profiles_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "posts_select_all": {
+          "name": "posts_select_all",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "public"
+          ],
+          "using": "true"
+        },
+        "posts_insert_self": {
+          "name": "posts_insert_self",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\"posts\".\"profile_id\" = (select id from profiles where auth_user_id = (select auth.uid()))"
+        },
+        "posts_update_self": {
+          "name": "posts_update_self",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\"posts\".\"profile_id\" = (select id from profiles where auth_user_id = (select auth.uid()))",
+          "withCheck": "\"posts\".\"profile_id\" = (select id from profiles where auth_user_id = (select auth.uid()))"
+        },
+        "posts_delete_self": {
+          "name": "posts_delete_self",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\"posts\".\"profile_id\" = (select id from profiles where auth_user_id = (select auth.uid()))"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profiles": {
+      "name": "profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "auth_user_id": {
+          "name": "auth_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profiles_auth_user_id_users_id_fk": {
+          "name": "profiles_auth_user_id_users_id_fk",
+          "tableFrom": "profiles",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": [
+            "auth_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "profiles_auth_user_id_unique": {
+          "name": "profiles_auth_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "auth_user_id"
+          ]
+        },
+        "profiles_username_unique": {
+          "name": "profiles_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {
+        "profiles_select_all": {
+          "name": "profiles_select_all",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "public"
+          ],
+          "using": "true"
+        },
+        "profiles_insert_self": {
+          "name": "profiles_insert_self",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\"profiles\".\"auth_user_id\" = (select auth.uid())"
+        },
+        "profiles_update_self": {
+          "name": "profiles_update_self",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\"profiles\".\"auth_user_id\" = (select auth.uid())",
+          "withCheck": "\"profiles\".\"auth_user_id\" = (select auth.uid())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.votes": {
+      "name": "votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "votable_type": {
+          "name": "votable_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "votable_id": {
+          "name": "votable_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "votes_profile_votable_index": {
+          "name": "votes_profile_votable_index",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "votable_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "votable_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "votes_profile_id_profiles_id_fk": {
+          "name": "votes_profile_id_profiles_id_fk",
+          "tableFrom": "votes",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "votes_select_own": {
+          "name": "votes_select_own",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\"votes\".\"profile_id\" = (select id from profiles where auth_user_id = (select auth.uid()))"
+        },
+        "votes_insert_own": {
+          "name": "votes_insert_own",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\"votes\".\"profile_id\" = (select id from profiles where auth_user_id = (select auth.uid()))"
+        },
+        "votes_update_own": {
+          "name": "votes_update_own",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\"votes\".\"profile_id\" = (select id from profiles where auth_user_id = (select auth.uid()))",
+          "withCheck": "\"votes\".\"profile_id\" = (select id from profiles where auth_user_id = (select auth.uid()))"
+        },
+        "votes_delete_own": {
+          "name": "votes_delete_own",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\"votes\".\"profile_id\" = (select id from profiles where auth_user_id = (select auth.uid()))"
+        }
+      },
+      "checkConstraints": {
+        "votes_votable_type_check": {
+          "name": "votes_votable_type_check",
+          "value": "\"votes\".\"votable_type\" in ('post', 'comment')"
+        },
+        "votes_value_check": {
+          "name": "votes_value_check",
+          "value": "\"votes\".\"value\" in (-1, 1)"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/drizzle/meta/0004_snapshot.json
+++ b/backend/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,512 @@
+{
+  "id": "cdb1112b-28b5-46d0-a0db-3ae7ac029d65",
+  "prevId": "b2da2696-a6f4-4956-b9a7-2c0e88f6bd53",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.comments": {
+      "name": "comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "comments_post_id_posts_id_fk": {
+          "name": "comments_post_id_posts_id_fk",
+          "tableFrom": "comments",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "tableTo": "posts",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "comments_profile_id_profiles_id_fk": {
+          "name": "comments_profile_id_profiles_id_fk",
+          "tableFrom": "comments",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "comments_select_all": {
+          "name": "comments_select_all",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "public"
+          ],
+          "using": "true"
+        },
+        "comments_insert_self": {
+          "name": "comments_insert_self",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\"comments\".\"profile_id\" = (select id from profiles where auth_user_id = (select auth.uid()))"
+        },
+        "comments_update_self": {
+          "name": "comments_update_self",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\"comments\".\"profile_id\" = (select id from profiles where auth_user_id = (select auth.uid()))",
+          "withCheck": "\"comments\".\"profile_id\" = (select id from profiles where auth_user_id = (select auth.uid()))"
+        },
+        "comments_delete_self": {
+          "name": "comments_delete_self",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\"comments\".\"profile_id\" = (select id from profiles where auth_user_id = (select auth.uid()))"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posts": {
+      "name": "posts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_pinned": {
+          "name": "is_pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "pinned_at": {
+          "name": "pinned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "posts_profile_id_profiles_id_fk": {
+          "name": "posts_profile_id_profiles_id_fk",
+          "tableFrom": "posts",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "posts_select_all": {
+          "name": "posts_select_all",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "public"
+          ],
+          "using": "true"
+        },
+        "posts_insert_self": {
+          "name": "posts_insert_self",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\"posts\".\"profile_id\" = (select id from profiles where auth_user_id = (select auth.uid()))"
+        },
+        "posts_update_self": {
+          "name": "posts_update_self",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\"posts\".\"profile_id\" = (select id from profiles where auth_user_id = (select auth.uid()))",
+          "withCheck": "\"posts\".\"profile_id\" = (select id from profiles where auth_user_id = (select auth.uid()))"
+        },
+        "posts_delete_self": {
+          "name": "posts_delete_self",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\"posts\".\"profile_id\" = (select id from profiles where auth_user_id = (select auth.uid()))"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profiles": {
+      "name": "profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "auth_user_id": {
+          "name": "auth_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profiles_auth_user_id_users_id_fk": {
+          "name": "profiles_auth_user_id_users_id_fk",
+          "tableFrom": "profiles",
+          "columnsFrom": [
+            "auth_user_id"
+          ],
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "profiles_auth_user_id_unique": {
+          "name": "profiles_auth_user_id_unique",
+          "columns": [
+            "auth_user_id"
+          ],
+          "nullsNotDistinct": false
+        },
+        "profiles_username_unique": {
+          "name": "profiles_username_unique",
+          "columns": [
+            "username"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {
+        "profiles_select_all": {
+          "name": "profiles_select_all",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "public"
+          ],
+          "using": "true"
+        },
+        "profiles_insert_self": {
+          "name": "profiles_insert_self",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\"profiles\".\"auth_user_id\" = (select auth.uid())"
+        },
+        "profiles_update_self": {
+          "name": "profiles_update_self",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\"profiles\".\"auth_user_id\" = (select auth.uid())",
+          "withCheck": "\"profiles\".\"auth_user_id\" = (select auth.uid())"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.votes": {
+      "name": "votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "votable_type": {
+          "name": "votable_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "votable_id": {
+          "name": "votable_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "votes_profile_votable_index": {
+          "name": "votes_profile_votable_index",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "votable_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "votable_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "votes_profile_id_profiles_id_fk": {
+          "name": "votes_profile_id_profiles_id_fk",
+          "tableFrom": "votes",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "tableTo": "profiles",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "votes_select_own": {
+          "name": "votes_select_own",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\"votes\".\"profile_id\" = (select id from profiles where auth_user_id = (select auth.uid()))"
+        },
+        "votes_insert_own": {
+          "name": "votes_insert_own",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "\"votes\".\"profile_id\" = (select id from profiles where auth_user_id = (select auth.uid()))"
+        },
+        "votes_update_own": {
+          "name": "votes_update_own",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\"votes\".\"profile_id\" = (select id from profiles where auth_user_id = (select auth.uid()))",
+          "withCheck": "\"votes\".\"profile_id\" = (select id from profiles where auth_user_id = (select auth.uid()))"
+        },
+        "votes_delete_own": {
+          "name": "votes_delete_own",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "\"votes\".\"profile_id\" = (select id from profiles where auth_user_id = (select auth.uid()))"
+        }
+      },
+      "checkConstraints": {
+        "votes_votable_type_check": {
+          "name": "votes_votable_type_check",
+          "value": "\"votes\".\"votable_type\" in ('post', 'comment')"
+        },
+        "votes_value_check": {
+          "name": "votes_value_check",
+          "value": "\"votes\".\"value\" in (-1, 1)"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "views": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/drizzle/meta/_journal.json
+++ b/backend/drizzle/meta/_journal.json
@@ -22,6 +22,20 @@
       "when": 1786289856669,
       "tag": "0002_grant_authenticated",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1788634313349,
+      "tag": "0003_sparkling_layla_miller",
+      "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1788638133977,
+      "tag": "0004_lock_is_pinned_column",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -12,7 +12,7 @@
 //     only so old posts still show an author; nobody can log in as them.
 
 import { sql } from 'drizzle-orm';
-import { pgTable, uuid, text, timestamp, smallint, check, uniqueIndex, pgPolicy } from 'drizzle-orm/pg-core';
+import { pgTable, uuid, text, boolean, timestamp, smallint, check, uniqueIndex, pgPolicy } from 'drizzle-orm/pg-core';
 import { authUsers, authenticatedRole } from 'drizzle-orm/supabase';
 
 export const profiles = pgTable(
@@ -62,8 +62,10 @@ export const posts = pgTable(
     profileId: uuid('profile_id').references(() => profiles.id, { onDelete: 'set null' }),
     title: text('title').notNull(),
     content: text('content').notNull(),
+    isPinned: boolean('is_pinned').notNull().default(false),
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+    pinnedAt: timestamp('pinned_at', { withTimezone: true }).notNull().defaultNow(),
   },
   (t) => [
     pgPolicy('posts_select_all', {

--- a/backend/src/forum/routes.ts
+++ b/backend/src/forum/routes.ts
@@ -4,7 +4,7 @@ import type { Bindings } from '../types';
 import { getDb, withUser } from '../db';
 import { posts, comments, profiles, votes } from '../db/schema';
 import { requireAuth, type AuthVars } from '../middleware/auth';
-import { createPostSchema, createCommentSchema, voteSchema, unvoteSchema } from './validation';
+import { createPostSchema, createCommentSchema, voteSchema, unvoteSchema, pinSchema } from './validation';
 import { resolvePageSize, resolveOffset } from './pagination';
 import { notify } from '../notify';
 
@@ -45,13 +45,14 @@ forum.get('/posts', async (c) => {
       id: posts.id,
       title: posts.title,
       content: posts.content,
+      isPinned: posts.isPinned,
       createdAt: posts.createdAt,
       score: postScore,
       author: { username: profiles.username, avatarUrl: profiles.avatarUrl, role: profiles.role },
     })
     .from(posts)
     .leftJoin(profiles, eq(profiles.id, posts.profileId))
-    .orderBy(sort === 'top' ? desc(postScore) : desc(posts.createdAt))
+    .orderBy(desc(posts.isPinned), sort === 'top' ? desc(postScore) : desc(posts.createdAt))
     .limit(limit)
     .offset(offset);
   const total = await db.$count(posts);
@@ -68,6 +69,7 @@ forum.get('/posts/:id', async (c) => {
       id: posts.id,
       title: posts.title,
       content: posts.content,
+      isPinned: posts.isPinned,
       createdAt: posts.createdAt,
       score: postScore,
       author: { username: profiles.username, avatarUrl: profiles.avatarUrl, role: profiles.role },
@@ -138,6 +140,23 @@ forum.post('/posts/:id/comments', requireAuth, async (c) => {
     path: `/forum/${c.req.param('id')}`,
   });
   return c.json(comment, 201);
+});
+
+forum.post('/posts/:id/pin', requireAuth, async (c) => {
+  // Admin-only. is_pinned is REVOKEd from the `authenticated` role (see the 0004 grants
+  // migration), so it can only be written via the privileged pooler role: plain getDb,
+  // NOT withUser. Authorization is enforced here in code.
+  if (c.get('profile').role !== 'admin') return c.json({ error: 'Forbidden' }, 403);
+  const parsed = pinSchema.safeParse(await c.req.json().catch(() => null));
+  if (!parsed.success) return c.json({ error: 'Invalid pin' }, 400);
+  const [updated] = await getDb(c.env)
+    .update(posts)
+    .set(parsed.data.pinned ? { isPinned: true, pinnedAt: new Date() } : { isPinned: false })
+    .where(eq(posts.id, c.req.param('id')!))
+    .returning({ id: posts.id, isPinned: posts.isPinned });
+  if (!updated) return c.json({ error: 'Post not found' }, 404);
+  purgeForum(c);
+  return c.json({ ok: true, isPinned: updated.isPinned });
 });
 
 forum.post('/vote', requireAuth, async (c) => {

--- a/backend/src/forum/validation.ts
+++ b/backend/src/forum/validation.ts
@@ -19,3 +19,7 @@ export const unvoteSchema = z.object({
   votableType: z.enum(['post', 'comment']),
   votableId: z.string().uuid(),
 });
+
+export const pinSchema = z.object({
+  pinned: z.boolean(),
+});

--- a/backend/test/forum/pin.test.ts
+++ b/backend/test/forum/pin.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { app } from '../../src/index';
+
+// Unit: POST /forum/posts/:id/pin is auth-gated, so an unauthenticated request is
+// rejected before any DB work. Admin authorization + the DB behavior (float to top,
+// unpin) are covered in the integration suite, which needs local Supabase.
+describe('POST /forum/posts/:id/pin (unit)', () => {
+  it('401s without an Authorization header', async () => {
+    const res = await app.request('/forum/posts/00000000-0000-0000-0000-000000000000/pin', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ pinned: true }),
+    });
+    expect(res.status).toBe(401);
+  });
+});

--- a/backend/test/integration/pin.test.ts
+++ b/backend/test/integration/pin.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { getDb } from '../../src/db';
+import { profiles } from '../../src/db/schema';
+import type { Bindings } from '../../src/types';
+import { env, isDbReachable, signUp, authHeader, appRequest } from './env';
+
+const dbUp = await isDbReachable();
+
+// Pinning is admin-only. There is no admin-granting endpoint (role is a profiles column),
+// so the test elevates a signed-up user to admin directly in the DB. is_pinned itself is
+// only writable by the privileged pooler role (see the 0004 grants migration); the endpoint
+// gates that path on the admin role.
+describe.skipIf(!dbUp)('POST /forum/posts/:id/pin (integration, local Supabase)', () => {
+  let admin: Awaited<ReturnType<typeof signUp>>;
+  let user: Awaited<ReturnType<typeof signUp>>;
+  let postId: string;
+
+  beforeAll(async () => {
+    admin = await signUp('pinadmin');
+    user = await signUp('pinuser');
+
+    // Trigger the admin's profile creation (requireAuth -> getOrCreateProfile), then elevate.
+    await appRequest('/user/me', { headers: authHeader(admin.accessToken) });
+    await getDb(env as unknown as Bindings)
+      .update(profiles)
+      .set({ role: 'admin' })
+      .where(eq(profiles.authUserId, admin.userId));
+
+    const res = await appRequest('/forum/posts', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...authHeader(user.accessToken) },
+      body: JSON.stringify({ title: `pin target ${Date.now()}`, content: 'seed content' }),
+    });
+    postId = ((await res.json()) as { id: string }).id;
+  });
+
+  it('401s without auth', async () => {
+    const res = await appRequest(`/forum/posts/${postId}/pin`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ pinned: true }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it('403s for a non-admin', async () => {
+    const res = await appRequest(`/forum/posts/${postId}/pin`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...authHeader(user.accessToken) },
+      body: JSON.stringify({ pinned: true }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it('lets an admin pin: post reports isPinned and floats to the top of the list', async () => {
+    const res = await appRequest(`/forum/posts/${postId}/pin`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...authHeader(admin.accessToken) },
+      body: JSON.stringify({ pinned: true }),
+    });
+    expect(res.status).toBe(200);
+    expect(((await res.json()) as { isPinned: boolean }).isPinned).toBe(true);
+
+    const list = await appRequest('/forum/posts?sort=new&limit=50&offset=0');
+    const body = (await list.json()) as { posts: { id: string; isPinned: boolean }[] };
+    expect(body.posts.find((p) => p.id === postId)?.isPinned).toBe(true);
+    expect(body.posts[0].isPinned).toBe(true); // pinned posts sort first
+  });
+
+  it('lets an admin unpin', async () => {
+    const res = await appRequest(`/forum/posts/${postId}/pin`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...authHeader(admin.accessToken) },
+      body: JSON.stringify({ pinned: false }),
+    });
+    expect(res.status).toBe(200);
+    expect(((await res.json()) as { isPinned: boolean }).isPinned).toBe(false);
+  });
+});

--- a/website/app/forum/[id]/PostPageClient.tsx
+++ b/website/app/forum/[id]/PostPageClient.tsx
@@ -2,7 +2,12 @@
 
 import React, { useState, useEffect, useCallback, useRef } from 'react';
 import Link from 'next/link';
-import { ArrowLeftIcon, ArrowUpIcon, ArrowDownIcon } from '@radix-ui/react-icons';
+import {
+  ArrowLeftIcon,
+  ArrowUpIcon,
+  ArrowDownIcon,
+  DrawingPinFilledIcon,
+} from '@radix-ui/react-icons';
 import { toast } from 'sonner';
 import { Button } from '../../../components/ui/button';
 import { Card, CardContent } from '../../../components/ui/card';
@@ -20,6 +25,7 @@ type PostDetail = {
   content: string;
   score: number;
   createdAt: string;
+  isPinned: boolean;
   author: { username: string | null };
 };
 
@@ -219,6 +225,11 @@ export default function PostPageClient({ id }: Props) {
 
         <Card className="mb-8">
           <CardContent className="py-8 px-6 border-none">
+            {post.isPinned && (
+              <span className="mb-2 inline-flex items-center gap-1 text-xs font-semibold text-brand">
+                <DrawingPinFilledIcon width="12" height="12" /> Pinned
+              </span>
+            )}
             <h1 className="text-3xl md:text-4xl font-semibold tracking-tight text-foreground mb-4">
               {post.title}
             </h1>

--- a/website/app/forum/page.tsx
+++ b/website/app/forum/page.tsx
@@ -3,7 +3,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { ArrowUpIcon, ArrowDownIcon } from '@radix-ui/react-icons';
+import { ArrowUpIcon, ArrowDownIcon, DrawingPinFilledIcon } from '@radix-ui/react-icons';
 import { toast } from 'sonner';
 import { Button } from '../../components/ui/button';
 import { Card } from '../../components/ui/card';
@@ -22,6 +22,7 @@ type PostRow = {
   content: string;
   score: number;
   createdAt: string;
+  isPinned: boolean;
   author: { username: string | null };
 };
 
@@ -293,6 +294,11 @@ export default function ForumPage() {
                     </div>
 
                     <div className="flex-1 min-w-0">
+                      {post.isPinned && (
+                        <span className="mb-1 inline-flex items-center gap-1 text-xs font-semibold text-brand">
+                          <DrawingPinFilledIcon width="11" height="11" /> Pinned
+                        </span>
+                      )}
                       <h2 className="text-lg font-semibold text-foreground hover:text-brand transition-colors mb-1">
                         <Link href={`/forum/${post.id}`}>{post.title}</Link>
                       </h2>


### PR DESCRIPTION
## Description

Pinned posts: an admin can pin a post so it floats to the top of the forum, and the database itself prevents anyone else from pinning. No pin UI yet (an admin console comes later) — this ships the data model, the admin-only endpoint, the DB safeguard, and the badge.

## Changes

**Backend**
- Schema: `is_pinned boolean not null default false` + `pinned_at timestamptz` on `posts`.
- `GET /forum/posts` and `/posts/:id` return `isPinned`, and `/posts` orders `desc(is_pinned)` first so pins float to the top.
- `POST /forum/posts/:id/pin` (body `{ pinned: boolean }`): **admin-only** (`profile.role`, 403 otherwise). Writes `is_pinned` via plain `getDb` (the privileged pooler role) + `purgeForum`. Not `withUser`.
- Migration `0004_lock_is_pinned_column`: `REVOKE UPDATE ON posts FROM authenticated` then `GRANT UPDATE (title, content) ON posts TO authenticated`. So `is_pinned`/`pinned_at` are writable **only** by the privileged role. No normal user can pin any post (including their own) via any endpoint or RLS. The endpoint's admin check plus this column lock are the two layers.

**Frontend**
- "Pinned" badge (pin icon) on the forum list and the post detail page. Pins already sort to the top via the backend order. No set-pin UI (admin console later).

## Testing

- Backend: `typecheck`, `lint`, `prettier`, unit tests (96% coverage) pass. Migration applies cleanly to local Supabase.
- Frontend: `tsc`, `eslint`, `prettier` clean.
- Manual: set `is_pinned` in Studio (or call the endpoint as an admin), confirm the post floats to top with the badge.

## Linked issues

Refs #

## Checklist

- [x] `tsc`, lint, format, and tests pass locally
- [x] New backend feature code has an endpoint + migration
- [x] Code is formatted and matches the surrounding style
- [x] Docs/comments updated where behavior changed

https://claude.ai/code/session_01TshP4HMuq9JDAJF924zHay