### PR TITLE
feat(website): preview solution workspace

### DIFF
--- a/website/app/contest/[contestYear]/[problemCode]/ProblemPageClient.tsx
+++ b/website/app/contest/[contestYear]/[problemCode]/ProblemPageClient.tsx
@@ -67,7 +67,7 @@ const formatSize = (bytes: number) =>
     ? `${(bytes / (1024 * 1024)).toFixed(1)}MB`
     : `${(bytes / 1024).toFixed(1)}KB`;
 
-const Problem = () => {
+const Problem = ({ headerControls }: { headerControls?: React.ReactNode }) => {
   const { contestYear, problemCode } = useParams<{
     contestYear: string;
     problemCode: string;
@@ -409,9 +409,12 @@ const Problem = () => {
 
         {/* Problem header */}
         <div className="mb-10">
-          <h1 className="text-3xl md:text-4xl font-semibold tracking-tight text-foreground">
-            {problemInfo?.name || `CCC ${contestYear} ${problemCode.toUpperCase()}`}
-          </h1>
+          <div className="flex flex-wrap items-start justify-between gap-4">
+            <h1 className="text-3xl md:text-4xl font-semibold tracking-tight text-foreground">
+              {problemInfo?.name || `CCC ${contestYear} ${problemCode.toUpperCase()}`}
+            </h1>
+            {headerControls}
+          </div>
           <div className="flex flex-wrap items-center gap-2 mt-4">
             {problemInfo?.difficulty && (
               <span
@@ -632,7 +635,7 @@ const Problem = () => {
                         <span>
                           {getFileSizeWarning(activeTest.inputBytes) ||
                             getFileSizeWarning(activeTest.outputBytes)}{' '}
-                          — preview is truncated, use the Download button for the full file
+                          — display is truncated, use the Download button for the full file
                         </span>
                       </p>
                     </div>

--- a/website/app/contest/[contestYear]/[problemCode]/ProblemPageClient.tsx
+++ b/website/app/contest/[contestYear]/[problemCode]/ProblemPageClient.tsx
@@ -17,9 +17,17 @@ import { Card, CardContent } from '../../../../components/ui/card';
 import { SectionContainer } from '../../../../components/ui/section-container';
 import { DownloadDialog } from '../../../../components/contest/DownloadDialog';
 import { Problem as ProblemType, problems } from '../../../../constants';
+import {
+  CONTEST_API_BASE,
+  contestDownloadUrl,
+  fetchContestList,
+  fetchContestPreview,
+  type ContestListResponse,
+  type ContestSolutionMeta,
+  type ContestTestMeta,
+} from '../../../../lib/contest-api';
 import dynamic from 'next/dynamic';
 
-const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? 'https://api.cccsolutions.ca';
 const LARGE_FILE_BYTES = 50 * 1024;
 
 const SyntaxHighlighter = dynamic(
@@ -35,29 +43,11 @@ interface TestCaseData {
   output: string | null;
 }
 
-interface TestMeta {
-  n: number;
-  sample: boolean;
-  inputBytes: number;
-  outputBytes: number;
-}
-
-interface SolutionMeta {
-  n: number;
-  ext: string;
-  bytes: number;
-}
-
 interface SolutionEntry {
   code: string;
   language: string;
   n: number;
   ext: string;
-}
-
-interface ListResponse {
-  tests: TestMeta[];
-  solutions: SolutionMeta[];
 }
 
 const SOLUTION_MISSING_MESSAGE =
@@ -90,8 +80,8 @@ const Problem = () => {
   const [testCaseState, setTestCaseState] = useState<'idle' | 'loading' | 'success' | 'error'>(
     'idle'
   );
-  const [tests, setTests] = useState<TestMeta[]>([]);
-  const [solutionsMeta, setSolutionsMeta] = useState<SolutionMeta[]>([]);
+  const [tests, setTests] = useState<ContestTestMeta[]>([]);
+  const [solutionsMeta, setSolutionsMeta] = useState<ContestSolutionMeta[]>([]);
   const [downloadOpen, setDownloadOpen] = useState(false);
   const [problemInfo, setProblemInfo] = useState<ProblemType | null>(null);
   const [loading, setLoading] = useState(true);
@@ -149,7 +139,7 @@ const Problem = () => {
       setListStatus('loading');
 
       try {
-        const res = await fetch(`${API_BASE}/contests/${contestYear}/${problemCode}/list`);
+        const res = await fetchContestList(contestYear, problemCode);
 
         // 400 means the year/code itself is invalid (e.g. j8, or a s/j code
         // before 2000) — a different situation from a real API failure.
@@ -162,7 +152,7 @@ const Problem = () => {
           return;
         }
         if (!res.ok) throw new Error(`list ${res.status}`);
-        const data: ListResponse = await res.json();
+        const data: ContestListResponse = await res.json();
         if (cancelled) return;
         setListStatus('ok');
 
@@ -176,8 +166,10 @@ const Problem = () => {
         const solutionEntries = await Promise.all(
           (data.solutions ?? []).map(async (s) => {
             try {
-              const sres = await fetch(
-                `${API_BASE}/contests/${contestYear}/${problemCode}/preview?file=solutions/${s.n}.${s.ext}`
+              const sres = await fetchContestPreview(
+                contestYear,
+                problemCode,
+                `solutions/${s.n}.${s.ext}`
               );
               if (!sres.ok) return null;
               const code = await sres.text();
@@ -223,11 +215,10 @@ const Problem = () => {
     };
   }, [contestYear, problemCode]);
 
-  const testFilePath = (test: TestMeta, kind: 'in' | 'out') =>
+  const testFilePath = (test: ContestTestMeta, kind: 'in' | 'out') =>
     `${test.sample ? 'tests/sample' : 'tests'}/${test.n}.${kind}`;
 
-  const downloadUrl = (relpath: string) =>
-    `${API_BASE}/contests/${contestYear}/${problemCode}/download?file=${relpath}`;
+  const downloadUrl = (relpath: string) => contestDownloadUrl(contestYear, problemCode, relpath);
 
   const fetchTestCase = async (idx: number) => {
     const test = tests[idx];
@@ -235,12 +226,10 @@ const Problem = () => {
     setTestCaseState('loading');
     setTestCaseData({ input: '', output: '' });
 
-    const base = `${API_BASE}/contests/${contestYear}/${problemCode}/preview`;
-
     try {
       const [inputResponse, outputResponse] = await Promise.all([
-        fetch(`${base}?file=${testFilePath(test, 'in')}`),
-        fetch(`${base}?file=${testFilePath(test, 'out')}`),
+        fetchContestPreview(contestYear, problemCode, testFilePath(test, 'in')),
+        fetchContestPreview(contestYear, problemCode, testFilePath(test, 'out')),
       ]);
 
       if (!inputResponse.ok && !outputResponse.ok) {
@@ -686,7 +675,7 @@ const Problem = () => {
       <DownloadDialog
         open={downloadOpen}
         onClose={() => setDownloadOpen(false)}
-        apiBase={API_BASE}
+        apiBase={CONTEST_API_BASE}
         year={contestYear}
         code={problemCode}
         tests={tests}

--- a/website/app/contest/[contestYear]/[problemCode]/new-solution-preview/CommentableCode.tsx
+++ b/website/app/contest/[contestYear]/[problemCode]/new-solution-preview/CommentableCode.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import dynamic from 'next/dynamic';
 import { useTheme } from 'next-themes';
-import { ChevronRightIcon, Cross2Icon, PlusIcon } from '@radix-ui/react-icons';
+import { ChevronRightIcon, Cross2Icon } from '@radix-ui/react-icons';
+import ReactMarkdown from 'react-markdown';
 import { oneDark, oneLight } from 'react-syntax-highlighter/dist/esm/styles/prism';
 import { Button } from '../../../../../components/ui/button';
 
@@ -15,12 +16,12 @@ const SyntaxHighlighter = dynamic(
   }
 );
 
-type LineRange = {
+type TextRange = {
   start: number;
   end: number;
 };
 
-type MockComment = LineRange & {
+type MockComment = TextRange & {
   id: number;
   author: string;
   body: string;
@@ -28,45 +29,155 @@ type MockComment = LineRange & {
   replies: string[];
 };
 
-const INITIAL_COMMENTS: MockComment[] = [
-  {
-    id: 1,
-    start: 6,
-    end: 6,
-    author: 'mnop',
-    body: 'Could we mention why this comparison is sufficient? It took me a second to connect it to the problem statement.',
-    when: '8 min ago',
-    replies: [],
-  },
-  {
-    id: 2,
-    start: 7,
-    end: 7,
-    author: 'william',
-    body: 'It may help to name this value as the number of tickets left after both deductions.',
-    when: '3 min ago',
-    replies: [],
-  },
-];
-
-function lineFromNode(node: Node | null): number | null {
-  const element = node instanceof Element ? node : node?.parentElement;
-  const line = element?.closest('[data-code-line]')?.getAttribute('data-code-line');
-  if (!line) return null;
-  const parsed = Number(line);
-  return Number.isFinite(parsed) ? parsed : null;
-}
-
-function lineLabel(range: LineRange): string {
-  return range.start === range.end ? `Line ${range.start}` : `Lines ${range.start}–${range.end}`;
-}
-
 const clamp = (value: number, min: number, max: number) => Math.min(max, Math.max(min, value));
+
+function lineStarts(code: string): number[] {
+  const starts = [0];
+  for (let index = 0; index < code.length; index += 1) {
+    if (code[index] === '\n') starts.push(index + 1);
+  }
+  return starts;
+}
+
+function lineForOffset(starts: number[], offset: number): number {
+  let line = 0;
+  while (line + 1 < starts.length && starts[line + 1] <= offset) line += 1;
+  return line;
+}
+
+function rangeLabel(code: string, range: TextRange): string {
+  const starts = lineStarts(code);
+  const first = lineForOffset(starts, range.start) + 1;
+  const last = lineForOffset(starts, Math.max(range.start, range.end - 1)) + 1;
+  return first === last ? `Line ${first}` : `Lines ${first}–${last}`;
+}
+
+function fallbackRange(code: string, preferredLine: number): TextRange {
+  const lines = code.split('\n');
+  const lineIndex = clamp(preferredLine - 1, 0, Math.max(0, lines.length - 1));
+  const starts = lineStarts(code);
+  const line = lines[lineIndex] ?? '';
+  const firstCharacter = line.search(/\S/);
+  const start = starts[lineIndex] + Math.max(0, firstCharacter);
+  const available = Math.max(1, line.trimStart().length);
+  return { start, end: Math.min(code.length, start + Math.min(available, 12)) };
+}
+
+function findRange(code: string, patterns: RegExp[], fallbackLine: number): TextRange {
+  for (const pattern of patterns) {
+    const match = pattern.exec(code);
+    if (match?.index !== undefined) {
+      return { start: match.index, end: match.index + match[0].length };
+    }
+  }
+  return fallbackRange(code, fallbackLine);
+}
+
+function findLastRange(code: string, patterns: RegExp[], fallbackLine: number): TextRange {
+  for (const pattern of patterns) {
+    const matches = Array.from(code.matchAll(new RegExp(pattern.source, `${pattern.flags}g`)));
+    const match = matches.at(-1);
+    if (match?.index !== undefined) {
+      return { start: match.index, end: match.index + match[0].length };
+    }
+  }
+  return fallbackRange(code, fallbackLine);
+}
+
+function initialComments(code: string): MockComment[] {
+  return [
+    {
+      id: 1,
+      ...findRange(code, [/t\s*-\s*p\s*<\s*b/i, /\(?T\s*-\s*P\s*-\s*B\)?\s*>=\s*0/i], 6),
+      author: 'mnop',
+      body: 'Could we mention why **this comparison** is sufficient? It took me a second to connect it to the problem statement.',
+      when: '8 min ago',
+      replies: [],
+    },
+    {
+      id: 2,
+      ...findLastRange(code, [/t\s*-\s*p\s*-\s*b/i, /T\s*-\s*P\s*-\s*B/i], 7),
+      author: 'william',
+      body: 'It may help to name this value as the number of tickets left after both deductions.',
+      when: '3 min ago',
+      replies: [],
+    },
+  ];
+}
+
+function codeTextNodes(line: Element): Text[] {
+  const nodes: Text[] = [];
+  const walker = document.createTreeWalker(line, NodeFilter.SHOW_TEXT);
+  let node = walker.nextNode();
+  while (node) {
+    const text = node as Text;
+    if (!text.parentElement?.closest('.react-syntax-highlighter-line-number')) nodes.push(text);
+    node = walker.nextNode();
+  }
+  return nodes;
+}
+
+function sourceOffsetFromDom(code: string, node: Node, offset: number): number | null {
+  const element = node instanceof Element ? node : node.parentElement;
+  const line = element?.closest('[data-code-line]');
+  const lineNumber = Number(line?.getAttribute('data-code-line'));
+  if (!line || !Number.isFinite(lineNumber)) return null;
+
+  const starts = lineStarts(code);
+  const sourceLine = code.split('\n')[lineNumber - 1] ?? '';
+  const prefix = document.createRange();
+  prefix.selectNodeContents(line);
+  try {
+    prefix.setEnd(node, offset);
+  } catch {
+    return starts[lineNumber - 1] ?? null;
+  }
+  const numberLength = line.querySelector('.react-syntax-highlighter-line-number')?.textContent
+    ?.length;
+  const character = clamp(prefix.toString().length - (numberLength ?? 0), 0, sourceLine.length);
+  return (starts[lineNumber - 1] ?? 0) + character;
+}
+
+function domPointForOffset(root: HTMLElement, code: string, offset: number) {
+  const starts = lineStarts(code);
+  const safeOffset = clamp(offset, 0, code.length);
+  const lineIndex = lineForOffset(starts, safeOffset);
+  const line = root.querySelector(`[data-code-line="${lineIndex + 1}"]`);
+  if (!line) return null;
+
+  let remaining = safeOffset - starts[lineIndex];
+  const nodes = codeTextNodes(line);
+  for (const node of nodes) {
+    if (remaining <= node.data.length) return { node, offset: remaining };
+    remaining -= node.data.length;
+  }
+  const last = nodes.at(-1);
+  return last ? { node: last, offset: last.data.length } : null;
+}
+
+function domRangeForText(root: HTMLElement, code: string, range: TextRange): Range | null {
+  const start = domPointForOffset(root, code, range.start);
+  const end = domPointForOffset(root, code, range.end);
+  if (!start || !end) return null;
+  const domRange = document.createRange();
+  domRange.setStart(start.node, start.offset);
+  domRange.setEnd(end.node, end.offset);
+  return domRange;
+}
+
+function CommentMarkdown({ children }: { children: string }) {
+  return (
+    <div className="text-xs leading-relaxed text-foreground-light [&_a]:text-brand [&_a:hover]:underline [&_code]:rounded [&_code]:bg-surface-200 [&_code]:px-1 [&_ol]:list-decimal [&_ol]:pl-4 [&_p]:m-0 [&_pre]:overflow-x-auto [&_strong]:font-semibold [&_ul]:list-disc [&_ul]:pl-4">
+      <ReactMarkdown>{children}</ReactMarkdown>
+    </div>
+  );
+}
 
 export function CommentableCode({
   code,
   language,
   commentsVisible,
+  composerRequest,
   onCloseComments,
   railWidth,
   onRailWidthChange,
@@ -74,6 +185,7 @@ export function CommentableCode({
   code: string;
   language: string;
   commentsVisible: boolean;
+  composerRequest: number;
   onCloseComments: () => void;
   railWidth: number;
   onRailWidthChange: (width: number) => void;
@@ -81,86 +193,205 @@ export function CommentableCode({
   const { resolvedTheme } = useTheme();
   const workspaceRef = useRef<HTMLDivElement>(null);
   const codeAreaRef = useRef<HTMLDivElement>(null);
-  const [comments, setComments] = useState<MockComment[]>(INITIAL_COMMENTS);
-  const [selection, setSelection] = useState<LineRange | null>(null);
+  const handledComposerRequest = useRef(composerRequest);
+  const [comments, setComments] = useState<MockComment[]>(() => initialComments(code));
+  const [target, setTarget] = useState<TextRange>({ start: 0, end: 0 });
   const [activeCommentId, setActiveCommentId] = useState<number | null>(null);
   const [composing, setComposing] = useState(false);
   const [draft, setDraft] = useState('');
   const [replyingToId, setReplyingToId] = useState<number | null>(null);
   const [replyDraft, setReplyDraft] = useState('');
+  const [highlightRects, setHighlightRects] = useState<
+    Array<{
+      key: string;
+      left: number;
+      top: number;
+      width: number;
+      height: number;
+      active: boolean;
+    }>
+  >([]);
+  const [caretRect, setCaretRect] = useState<{
+    left: number;
+    top: number;
+    height: number;
+  } | null>(null);
 
-  const lineCount = useMemo(() => Math.max(1, code.split('\n').length), [code]);
   const codeStyle = resolvedTheme === 'dark' ? oneDark : oneLight;
 
   useEffect(() => {
     if (commentsVisible) return;
-    setSelection(null);
     setActiveCommentId(null);
     setComposing(false);
     setReplyingToId(null);
-    window.getSelection()?.removeAllRanges();
   }, [commentsVisible]);
 
-  const commentForLine = (line: number) =>
-    comments.find((comment) => line >= comment.start && line <= comment.end);
-
-  const lineBackground = (line: number) => {
-    if (selection && line >= selection.start && line <= selection.end) {
-      return 'hsl(var(--brand-300) / 0.72)';
-    }
-
-    const comment = commentForLine(line);
-    if (!commentsVisible || !comment) return 'transparent';
-    return comment.id === activeCommentId
-      ? 'hsl(var(--brand-300) / 0.72)'
-      : 'hsl(var(--brand-300) / 0.34)';
-  };
-
-  const handleSelection = () => {
-    if (!commentsVisible) return;
-    const browserSelection = window.getSelection();
-    if (
-      !browserSelection ||
-      browserSelection.isCollapsed ||
-      !browserSelection.anchorNode ||
-      !browserSelection.focusNode ||
-      !codeAreaRef.current?.contains(browserSelection.anchorNode) ||
-      !codeAreaRef.current.contains(browserSelection.focusNode)
-    ) {
-      return;
-    }
-
-    const anchorLine = lineFromNode(browserSelection.anchorNode);
-    const focusLine = lineFromNode(browserSelection.focusNode);
-    if (anchorLine === null || focusLine === null || !browserSelection.toString().trim()) return;
-
-    setSelection({
-      start: Math.min(anchorLine, focusLine),
-      end: Math.max(anchorLine, focusLine),
-    });
+  useEffect(() => {
+    if (composerRequest === handledComposerRequest.current) return;
+    handledComposerRequest.current = composerRequest;
     setActiveCommentId(null);
-    setComposing(false);
+    setReplyingToId(null);
+    setDraft('');
+    setComposing(true);
+  }, [composerRequest]);
+
+  useEffect(() => {
+    const root = codeAreaRef.current;
+    if (!root) return;
+    let frame = 0;
+
+    const measure = () => {
+      const rootRect = root.getBoundingClientRect();
+      const nextHighlights: typeof highlightRects = [];
+      const ranges: Array<{ key: string; range: TextRange; active: boolean }> = commentsVisible
+        ? comments.map((comment) => ({
+            key: `comment-${comment.id}`,
+            range: comment,
+            active: comment.id === activeCommentId,
+          }))
+        : [];
+
+      if (target.end > target.start && activeCommentId === null) {
+        ranges.push({ key: 'target', range: target, active: true });
+      }
+
+      ranges.forEach(({ key, range, active }) => {
+        const domRange = domRangeForText(root, code, range);
+        if (!domRange) return;
+        Array.from(domRange.getClientRects()).forEach((rect, index) => {
+          if (rect.width <= 0 || rect.height <= 0) return;
+          nextHighlights.push({
+            key: `${key}-${index}`,
+            left: rect.left - rootRect.left + root.scrollLeft,
+            top: rect.top - rootRect.top + root.scrollTop,
+            width: rect.width,
+            height: rect.height,
+            active,
+          });
+        });
+      });
+      setHighlightRects(nextHighlights);
+
+      const caretPoint = domPointForOffset(root, code, target.end);
+      if (!caretPoint) {
+        setCaretRect(null);
+        return;
+      }
+      const caretRange = document.createRange();
+      caretRange.setStart(caretPoint.node, caretPoint.offset);
+      caretRange.collapse(true);
+      let rect = caretRange.getBoundingClientRect();
+      let caretLeft = rect.left;
+
+      if (rect.height <= 0) {
+        const probeStart = target.end < code.length ? target.end : Math.max(0, target.end - 1);
+        const probeEnd = Math.min(code.length, probeStart + 1);
+        const probe = domRangeForText(root, code, { start: probeStart, end: probeEnd });
+        const probeRect = probe?.getClientRects()[0];
+        if (!probeRect) {
+          setCaretRect(null);
+          return;
+        }
+        rect = probeRect;
+        caretLeft = target.end < code.length ? rect.left : rect.right;
+      }
+
+      setCaretRect({
+        left: caretLeft - rootRect.left + root.scrollLeft,
+        top: rect.top - rootRect.top + root.scrollTop,
+        height: rect.height,
+      });
+    };
+
+    const scheduleMeasure = () => {
+      window.cancelAnimationFrame(frame);
+      frame = window.requestAnimationFrame(measure);
+    };
+    const resizeObserver = new ResizeObserver(scheduleMeasure);
+    const mutationObserver = new MutationObserver((mutations) => {
+      const codeChanged = mutations.some((mutation) =>
+        Array.from(mutation.addedNodes).some(
+          (node) =>
+            node instanceof Element &&
+            (node.matches('[data-code-line]') || node.querySelector('[data-code-line]'))
+        )
+      );
+      if (codeChanged) scheduleMeasure();
+    });
+    resizeObserver.observe(root);
+    mutationObserver.observe(root, { childList: true, subtree: true });
+    window.addEventListener('resize', scheduleMeasure);
+    scheduleMeasure();
+
+    return () => {
+      window.cancelAnimationFrame(frame);
+      resizeObserver.disconnect();
+      mutationObserver.disconnect();
+      window.removeEventListener('resize', scheduleMeasure);
+    };
+  }, [activeCommentId, code, comments, commentsVisible, target]);
+
+  const handleSelection = (event: React.MouseEvent<HTMLDivElement>) => {
+    const browserSelection = window.getSelection();
+    const codeArea = codeAreaRef.current;
+    let nextTarget: TextRange | null = null;
+
+    if (browserSelection && !browserSelection.isCollapsed && codeArea) {
+      const nativeRange = browserSelection.getRangeAt(0);
+      if (
+        codeArea.contains(nativeRange.startContainer) &&
+        codeArea.contains(nativeRange.endContainer)
+      ) {
+        const start = sourceOffsetFromDom(
+          code,
+          nativeRange.startContainer,
+          nativeRange.startOffset
+        );
+        const end = sourceOffsetFromDom(code, nativeRange.endContainer, nativeRange.endOffset);
+        if (start !== null && end !== null && end > start) nextTarget = { start, end };
+      }
+    }
+
+    if (!nextTarget) {
+      const documentWithCaret = document as Document & {
+        caretPositionFromPoint?: (x: number, y: number) => CaretPosition | null;
+        caretRangeFromPoint?: (x: number, y: number) => Range | null;
+      };
+      const caretPosition = documentWithCaret.caretPositionFromPoint?.(
+        event.clientX,
+        event.clientY
+      );
+      const fallbackRange = documentWithCaret.caretRangeFromPoint?.(event.clientX, event.clientY);
+      const node = caretPosition?.offsetNode ?? fallbackRange?.startContainer;
+      const offset = caretPosition?.offset ?? fallbackRange?.startOffset;
+      if (node && offset !== undefined) {
+        const sourceOffset = sourceOffsetFromDom(code, node, offset);
+        if (sourceOffset !== null) nextTarget = { start: sourceOffset, end: sourceOffset };
+      }
+    }
+
+    if (!nextTarget) return;
+    setTarget(nextTarget);
+    const comment = comments.find(
+      (entry) => nextTarget.start >= entry.start && nextTarget.start <= entry.end
+    );
+    setActiveCommentId(commentsVisible ? (comment?.id ?? null) : null);
     setReplyingToId(null);
   };
 
   const activateComment = (id: number) => {
+    const comment = comments.find((entry) => entry.id === id);
+    if (comment) setTarget({ start: comment.start, end: comment.end });
     setActiveCommentId(id);
-    setSelection(null);
     setComposing(false);
     setReplyingToId(null);
     window.getSelection()?.removeAllRanges();
   };
 
-  const openComposer = () => {
-    setActiveCommentId(null);
-    setComposing(true);
-    setDraft('');
-  };
-
   const addComment = () => {
-    if (!selection || !draft.trim()) return;
+    if (!draft.trim()) return;
     const comment: MockComment = {
-      ...selection,
+      ...target,
       id: Date.now(),
       author: 'you',
       body: draft.trim(),
@@ -169,7 +400,6 @@ export function CommentableCode({
     };
     setComments((current) => [...current, comment]);
     setActiveCommentId(comment.id);
-    setSelection(null);
     setComposing(false);
     setDraft('');
     window.getSelection()?.removeAllRanges();
@@ -177,9 +407,7 @@ export function CommentableCode({
 
   const cancelComposer = () => {
     setComposing(false);
-    setSelection(null);
     setDraft('');
-    window.getSelection()?.removeAllRanges();
   };
 
   const addReply = (commentId: number) => {
@@ -222,8 +450,30 @@ export function CommentableCode({
       <div
         ref={codeAreaRef}
         onMouseUp={handleSelection}
-        className="relative min-w-0 flex-1 overflow-auto"
+        className="relative min-w-0 flex-1 cursor-text overflow-auto"
       >
+        <div className="pointer-events-none absolute inset-0 z-[2]" aria-hidden="true">
+          {highlightRects.map((rect) => (
+            <span
+              key={rect.key}
+              className={`absolute rounded-[2px] ${
+                rect.active ? 'bg-brand-400/50' : 'bg-brand-400/25'
+              }`}
+              style={{
+                left: rect.left,
+                top: rect.top,
+                width: rect.width,
+                height: rect.height,
+              }}
+            />
+          ))}
+          {caretRect && (
+            <span
+              className="absolute w-0.5 animate-pulse bg-brand-500"
+              style={{ left: caretRect.left, top: caretRect.top, height: caretRect.height }}
+            />
+          )}
+        </div>
         <SyntaxHighlighter
           language={language}
           style={codeStyle}
@@ -238,40 +488,21 @@ export function CommentableCode({
             fontSize: '13px',
             lineHeight: '20px',
             padding: '16px 48px 16px 16px',
+            position: 'relative',
+            zIndex: 1,
           }}
           codeTagProps={{ style: { background: 'transparent' } }}
           lineNumberStyle={{ minWidth: '2.75em', paddingRight: '1em', opacity: 0.45 }}
           lineProps={(lineNumber) => ({
             'data-code-line': lineNumber,
-            onClick: () => {
-              const browserSelection = window.getSelection();
-              if (browserSelection && !browserSelection.isCollapsed) return;
-              const comment = commentForLine(lineNumber);
-              if (commentsVisible && comment) activateComment(comment.id);
-            },
             style: {
               display: 'block',
               minWidth: 'max-content',
-              cursor: commentsVisible && commentForLine(lineNumber) ? 'pointer' : 'text',
-              background: lineBackground(lineNumber),
             },
           })}
         >
           {code || '// No solution code available'}
         </SyntaxHighlighter>
-
-        {commentsVisible && selection && !composing && (
-          <button
-            type="button"
-            onClick={openComposer}
-            className="absolute right-2 z-20 flex size-7 items-center justify-center rounded-full border border-brand-highlight bg-brand-500 text-white shadow-md hover:brightness-110"
-            style={{ top: `${16 + (Math.min(selection.start, lineCount) - 1) * 20}px` }}
-            aria-label={`Comment on ${lineLabel(selection).toLowerCase()}`}
-            title="Add comment"
-          >
-            <PlusIcon width="15" height="15" />
-          </button>
-        )}
       </div>
 
       {commentsVisible && (
@@ -314,6 +545,54 @@ export function CommentableCode({
                 <ChevronRightIcon width="14" height="14" />
               </button>
             </div>
+            {composing && (
+              <div className="shrink-0 border-b border-border-default p-2">
+                <article className="rounded-lg border border-brand-highlight bg-surface-100 p-3 shadow-sm">
+                  <div className="mb-2 flex items-center justify-between gap-2">
+                    <span className="text-xs font-semibold text-foreground">
+                      New comment · {rangeLabel(code, target)}
+                    </span>
+                    <button
+                      type="button"
+                      onClick={cancelComposer}
+                      className="rounded p-1 text-foreground-lighter hover:bg-surface-200 hover:text-foreground"
+                      aria-label="Cancel comment"
+                    >
+                      <Cross2Icon width="13" height="13" />
+                    </button>
+                  </div>
+                  {target.end > target.start && (
+                    <p className="mb-2 line-clamp-2 border-l-2 border-brand-400 pl-2 font-mono text-[10px] text-foreground-lighter">
+                      {code.slice(target.start, target.end)}
+                    </p>
+                  )}
+                  <textarea
+                    value={draft}
+                    onChange={(event) => setDraft(event.target.value)}
+                    placeholder="Add a comment…"
+                    autoFocus
+                    rows={3}
+                    className="w-full resize-none rounded-md border border-border-strong bg-background px-2.5 py-2 text-xs text-foreground placeholder:text-foreground-lighter focus:border-brand-highlight focus:outline-none"
+                  />
+                  <div className="mt-2 flex items-center justify-between gap-2">
+                    <span className="text-[10px] text-foreground-lighter">Markdown supported</span>
+                    <div className="flex gap-2">
+                      <Button type="default" size="tiny" onClick={cancelComposer}>
+                        Cancel
+                      </Button>
+                      <Button
+                        type="primary"
+                        size="tiny"
+                        onClick={addComment}
+                        disabled={!draft.trim()}
+                      >
+                        Comment
+                      </Button>
+                    </div>
+                  </div>
+                </article>
+              </div>
+            )}
             <div className="min-h-0 flex-1 space-y-2 overflow-y-auto p-2">
               {comments.map((comment) => {
                 const active = comment.id === activeCommentId;
@@ -337,7 +616,7 @@ export function CommentableCode({
                         {comment.when}
                       </span>
                     </div>
-                    <p className="text-xs leading-relaxed text-foreground-light">{comment.body}</p>
+                    <CommentMarkdown>{comment.body}</CommentMarkdown>
 
                     {comment.replies.map((reply, index) => (
                       <div
@@ -345,9 +624,9 @@ export function CommentableCode({
                         className="mt-3 border-l-2 border-border-strong pl-2"
                       >
                         <span className="text-[11px] font-semibold text-foreground">@you</span>
-                        <p className="mt-0.5 text-xs leading-relaxed text-foreground-light">
-                          {reply}
-                        </p>
+                        <div className="mt-0.5">
+                          <CommentMarkdown>{reply}</CommentMarkdown>
+                        </div>
                       </div>
                     ))}
 
@@ -399,45 +678,6 @@ export function CommentableCode({
                   </article>
                 );
               })}
-
-              {composing && selection && (
-                <article className="rounded-lg border border-brand-highlight bg-surface-100 p-3 shadow-sm">
-                  <div className="mb-2 flex items-center justify-between gap-2">
-                    <span className="text-xs font-semibold text-foreground">
-                      New comment · {lineLabel(selection)}
-                    </span>
-                    <button
-                      type="button"
-                      onClick={cancelComposer}
-                      className="rounded p-1 text-foreground-lighter hover:bg-surface-200 hover:text-foreground"
-                      aria-label="Cancel comment"
-                    >
-                      <Cross2Icon width="13" height="13" />
-                    </button>
-                  </div>
-                  <textarea
-                    value={draft}
-                    onChange={(event) => setDraft(event.target.value)}
-                    placeholder="Add a comment…"
-                    autoFocus
-                    rows={3}
-                    className="w-full resize-none rounded-md border border-border-strong bg-background px-2.5 py-2 text-xs text-foreground placeholder:text-foreground-lighter focus:border-brand-highlight focus:outline-none"
-                  />
-                  <div className="mt-2 flex justify-end gap-2">
-                    <Button type="default" size="tiny" onClick={cancelComposer}>
-                      Cancel
-                    </Button>
-                    <Button
-                      type="primary"
-                      size="tiny"
-                      onClick={addComment}
-                      disabled={!draft.trim()}
-                    >
-                      Comment
-                    </Button>
-                  </div>
-                </article>
-              )}
             </div>
           </aside>
         </>

--- a/website/app/contest/[contestYear]/[problemCode]/new-solution-preview/CommentableCode.tsx
+++ b/website/app/contest/[contestYear]/[problemCode]/new-solution-preview/CommentableCode.tsx
@@ -3,7 +3,7 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import dynamic from 'next/dynamic';
 import { useTheme } from 'next-themes';
-import { Cross2Icon, PlusIcon } from '@radix-ui/react-icons';
+import { ChevronRightIcon, Cross2Icon, PlusIcon } from '@radix-ui/react-icons';
 import { oneDark, oneLight } from 'react-syntax-highlighter/dist/esm/styles/prism';
 import { Button } from '../../../../../components/ui/button';
 
@@ -61,16 +61,25 @@ function lineLabel(range: LineRange): string {
   return range.start === range.end ? `Line ${range.start}` : `Lines ${range.start}–${range.end}`;
 }
 
+const clamp = (value: number, min: number, max: number) => Math.min(max, Math.max(min, value));
+
 export function CommentableCode({
   code,
   language,
   commentsVisible,
+  onCloseComments,
+  railWidth,
+  onRailWidthChange,
 }: {
   code: string;
   language: string;
   commentsVisible: boolean;
+  onCloseComments: () => void;
+  railWidth: number;
+  onRailWidthChange: (width: number) => void;
 }) {
   const { resolvedTheme } = useTheme();
+  const workspaceRef = useRef<HTMLDivElement>(null);
   const codeAreaRef = useRef<HTMLDivElement>(null);
   const [comments, setComments] = useState<MockComment[]>(INITIAL_COMMENTS);
   const [selection, setSelection] = useState<LineRange | null>(null);
@@ -186,8 +195,30 @@ export function CommentableCode({
     setReplyDraft('');
   };
 
+  const startRailResize = (event: React.PointerEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    const workspace = workspaceRef.current;
+    if (!workspace) return;
+    const rect = workspace.getBoundingClientRect();
+    const previousUserSelect = document.body.style.userSelect;
+    document.body.style.userSelect = 'none';
+
+    const move = (pointerEvent: PointerEvent) => {
+      const maxWidth = Math.max(176, Math.min(440, rect.width * 0.5, rect.width - 180));
+      onRailWidthChange(clamp(rect.right - pointerEvent.clientX, 176, maxWidth));
+    };
+    const stop = () => {
+      document.body.style.userSelect = previousUserSelect;
+      window.removeEventListener('pointermove', move);
+      window.removeEventListener('pointerup', stop);
+    };
+
+    window.addEventListener('pointermove', move);
+    window.addEventListener('pointerup', stop);
+  };
+
   return (
-    <div className="flex size-full min-h-0 overflow-hidden bg-surface-100">
+    <div ref={workspaceRef} className="flex size-full min-h-0 overflow-hidden bg-surface-100">
       <div
         ref={codeAreaRef}
         onMouseUp={handleSelection}
@@ -244,129 +275,172 @@ export function CommentableCode({
       </div>
 
       {commentsVisible && (
-        <aside
-          className="w-[min(17rem,42%)] min-w-52 shrink-0 overflow-y-auto border-l border-border-default bg-background p-2"
-          aria-label="Inline comments"
-        >
-          <div className="space-y-2">
-            {comments.map((comment) => {
-              const active = comment.id === activeCommentId;
-              const replying = comment.id === replyingToId;
+        <>
+          <button
+            type="button"
+            role="separator"
+            aria-label="Resize comments"
+            aria-orientation="vertical"
+            aria-valuemin={176}
+            aria-valuemax={440}
+            aria-valuenow={Math.round(railWidth)}
+            onPointerDown={startRailResize}
+            onKeyDown={(event) => {
+              if (event.key === 'ArrowLeft') {
+                onRailWidthChange(clamp(railWidth + 16, 176, 440));
+              }
+              if (event.key === 'ArrowRight') {
+                onRailWidthChange(clamp(railWidth - 16, 176, 440));
+              }
+            }}
+            className="group relative w-3 shrink-0 touch-none cursor-col-resize focus:outline-none"
+          >
+            <span className="absolute inset-y-2 left-1/2 w-px -translate-x-1/2 bg-border-strong transition-colors group-hover:bg-brand-400 group-focus:bg-brand-400" />
+          </button>
+          <aside
+            className="flex min-w-44 max-w-[50%] shrink-0 flex-col overflow-hidden bg-background"
+            style={{ width: `${railWidth}px` }}
+            aria-label="Inline comments"
+          >
+            <div className="flex h-10 shrink-0 items-center justify-between border-b border-border-default px-3">
+              <span className="text-xs font-semibold text-foreground">Comments</span>
+              <button
+                type="button"
+                onClick={onCloseComments}
+                className="rounded p-1.5 text-foreground-lighter transition-colors hover:bg-surface-200 hover:text-foreground"
+                aria-label="Close comments"
+                title="Close comments"
+              >
+                <ChevronRightIcon width="14" height="14" />
+              </button>
+            </div>
+            <div className="min-h-0 flex-1 space-y-2 overflow-y-auto p-2">
+              {comments.map((comment) => {
+                const active = comment.id === activeCommentId;
+                const replying = comment.id === replyingToId;
 
-              return (
-                <article
-                  key={comment.id}
-                  onClick={() => activateComment(comment.id)}
-                  className={`cursor-pointer rounded-lg border p-3 transition-colors ${
-                    active
-                      ? 'border-brand-highlight bg-surface-200 shadow-sm'
-                      : 'border-border-default bg-surface-100 hover:border-border-strong'
-                  }`}
-                >
-                  <div className="mb-2 flex items-baseline justify-between gap-2">
-                    <span className="text-xs font-semibold text-foreground">@{comment.author}</span>
-                    <span className="shrink-0 text-[10px] text-foreground-lighter">
-                      {comment.when}
-                    </span>
-                  </div>
-                  <p className="text-xs leading-relaxed text-foreground-light">{comment.body}</p>
-
-                  {comment.replies.map((reply, index) => (
-                    <div
-                      key={`${comment.id}-reply-${index}`}
-                      className="mt-3 border-l-2 border-border-strong pl-2"
-                    >
-                      <span className="text-[11px] font-semibold text-foreground">@you</span>
-                      <p className="mt-0.5 text-xs leading-relaxed text-foreground-light">
-                        {reply}
-                      </p>
+                return (
+                  <article
+                    key={comment.id}
+                    onClick={() => activateComment(comment.id)}
+                    className={`cursor-pointer rounded-lg border p-3 transition-colors ${
+                      active
+                        ? 'border-brand-highlight bg-surface-200 shadow-sm'
+                        : 'border-border-default bg-surface-100 hover:border-border-strong'
+                    }`}
+                  >
+                    <div className="mb-2 flex items-baseline justify-between gap-2">
+                      <span className="text-xs font-semibold text-foreground">
+                        @{comment.author}
+                      </span>
+                      <span className="shrink-0 text-[10px] text-foreground-lighter">
+                        {comment.when}
+                      </span>
                     </div>
-                  ))}
+                    <p className="text-xs leading-relaxed text-foreground-light">{comment.body}</p>
 
-                  {replying ? (
-                    <div className="mt-3 space-y-2" onClick={(event) => event.stopPropagation()}>
-                      <textarea
-                        value={replyDraft}
-                        onChange={(event) => setReplyDraft(event.target.value)}
-                        placeholder="Reply…"
-                        autoFocus
-                        rows={2}
-                        className="w-full resize-none rounded-md border border-border-strong bg-background px-2.5 py-2 text-xs text-foreground placeholder:text-foreground-lighter focus:border-brand-highlight focus:outline-none"
-                      />
-                      <div className="flex justify-end gap-2">
-                        <Button
-                          type="default"
-                          size="tiny"
-                          onClick={() => {
-                            setReplyingToId(null);
-                            setReplyDraft('');
-                          }}
-                        >
-                          Cancel
-                        </Button>
-                        <Button
-                          type="primary"
-                          size="tiny"
-                          onClick={() => addReply(comment.id)}
-                          disabled={!replyDraft.trim()}
-                        >
-                          Reply
-                        </Button>
+                    {comment.replies.map((reply, index) => (
+                      <div
+                        key={`${comment.id}-reply-${index}`}
+                        className="mt-3 border-l-2 border-border-strong pl-2"
+                      >
+                        <span className="text-[11px] font-semibold text-foreground">@you</span>
+                        <p className="mt-0.5 text-xs leading-relaxed text-foreground-light">
+                          {reply}
+                        </p>
                       </div>
-                    </div>
-                  ) : (
+                    ))}
+
+                    {replying ? (
+                      <div className="mt-3 space-y-2" onClick={(event) => event.stopPropagation()}>
+                        <textarea
+                          value={replyDraft}
+                          onChange={(event) => setReplyDraft(event.target.value)}
+                          placeholder="Reply…"
+                          autoFocus
+                          rows={2}
+                          className="w-full resize-none rounded-md border border-border-strong bg-background px-2.5 py-2 text-xs text-foreground placeholder:text-foreground-lighter focus:border-brand-highlight focus:outline-none"
+                        />
+                        <div className="flex justify-end gap-2">
+                          <Button
+                            type="default"
+                            size="tiny"
+                            onClick={() => {
+                              setReplyingToId(null);
+                              setReplyDraft('');
+                            }}
+                          >
+                            Cancel
+                          </Button>
+                          <Button
+                            type="primary"
+                            size="tiny"
+                            onClick={() => addReply(comment.id)}
+                            disabled={!replyDraft.trim()}
+                          >
+                            Reply
+                          </Button>
+                        </div>
+                      </div>
+                    ) : (
+                      <button
+                        type="button"
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          activateComment(comment.id);
+                          setReplyingToId(comment.id);
+                          setReplyDraft('');
+                        }}
+                        className="mt-2 text-xs font-medium text-brand hover:underline"
+                      >
+                        Reply
+                      </button>
+                    )}
+                  </article>
+                );
+              })}
+
+              {composing && selection && (
+                <article className="rounded-lg border border-brand-highlight bg-surface-100 p-3 shadow-sm">
+                  <div className="mb-2 flex items-center justify-between gap-2">
+                    <span className="text-xs font-semibold text-foreground">
+                      New comment · {lineLabel(selection)}
+                    </span>
                     <button
                       type="button"
-                      onClick={(event) => {
-                        event.stopPropagation();
-                        activateComment(comment.id);
-                        setReplyingToId(comment.id);
-                        setReplyDraft('');
-                      }}
-                      className="mt-2 text-xs font-medium text-brand hover:underline"
+                      onClick={cancelComposer}
+                      className="rounded p-1 text-foreground-lighter hover:bg-surface-200 hover:text-foreground"
+                      aria-label="Cancel comment"
                     >
-                      Reply
+                      <Cross2Icon width="13" height="13" />
                     </button>
-                  )}
+                  </div>
+                  <textarea
+                    value={draft}
+                    onChange={(event) => setDraft(event.target.value)}
+                    placeholder="Add a comment…"
+                    autoFocus
+                    rows={3}
+                    className="w-full resize-none rounded-md border border-border-strong bg-background px-2.5 py-2 text-xs text-foreground placeholder:text-foreground-lighter focus:border-brand-highlight focus:outline-none"
+                  />
+                  <div className="mt-2 flex justify-end gap-2">
+                    <Button type="default" size="tiny" onClick={cancelComposer}>
+                      Cancel
+                    </Button>
+                    <Button
+                      type="primary"
+                      size="tiny"
+                      onClick={addComment}
+                      disabled={!draft.trim()}
+                    >
+                      Comment
+                    </Button>
+                  </div>
                 </article>
-              );
-            })}
-
-            {composing && selection && (
-              <article className="rounded-lg border border-brand-highlight bg-surface-100 p-3 shadow-sm">
-                <div className="mb-2 flex items-center justify-between gap-2">
-                  <span className="text-xs font-semibold text-foreground">
-                    New comment · {lineLabel(selection)}
-                  </span>
-                  <button
-                    type="button"
-                    onClick={cancelComposer}
-                    className="rounded p-1 text-foreground-lighter hover:bg-surface-200 hover:text-foreground"
-                    aria-label="Cancel comment"
-                  >
-                    <Cross2Icon width="13" height="13" />
-                  </button>
-                </div>
-                <textarea
-                  value={draft}
-                  onChange={(event) => setDraft(event.target.value)}
-                  placeholder="Add a comment…"
-                  autoFocus
-                  rows={3}
-                  className="w-full resize-none rounded-md border border-border-strong bg-background px-2.5 py-2 text-xs text-foreground placeholder:text-foreground-lighter focus:border-brand-highlight focus:outline-none"
-                />
-                <div className="mt-2 flex justify-end gap-2">
-                  <Button type="default" size="tiny" onClick={cancelComposer}>
-                    Cancel
-                  </Button>
-                  <Button type="primary" size="tiny" onClick={addComment} disabled={!draft.trim()}>
-                    Comment
-                  </Button>
-                </div>
-              </article>
-            )}
-          </div>
-        </aside>
+              )}
+            </div>
+          </aside>
+        </>
       )}
     </div>
   );

--- a/website/app/contest/[contestYear]/[problemCode]/new-solution-preview/CommentableCode.tsx
+++ b/website/app/contest/[contestYear]/[problemCode]/new-solution-preview/CommentableCode.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import React, { useMemo, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import dynamic from 'next/dynamic';
 import { useTheme } from 'next-themes';
-import { ChatBubbleIcon, Cross2Icon, PlusIcon } from '@radix-ui/react-icons';
+import { Cross2Icon, PlusIcon } from '@radix-ui/react-icons';
 import { oneDark, oneLight } from 'react-syntax-highlighter/dist/esm/styles/prism';
 import { Button } from '../../../../../components/ui/button';
 
@@ -18,7 +18,6 @@ const SyntaxHighlighter = dynamic(
 type LineRange = {
   start: number;
   end: number;
-  quote: string;
 };
 
 type MockComment = LineRange & {
@@ -26,17 +25,27 @@ type MockComment = LineRange & {
   author: string;
   body: string;
   when: string;
+  replies: string[];
 };
 
 const INITIAL_COMMENTS: MockComment[] = [
   {
     id: 1,
-    start: 4,
-    end: 5,
-    quote: 'This branch decides whether the remaining tickets are enough.',
+    start: 6,
+    end: 6,
     author: 'mnop',
     body: 'Could we mention why this comparison is sufficient? It took me a second to connect it to the problem statement.',
     when: '8 min ago',
+    replies: [],
+  },
+  {
+    id: 2,
+    start: 7,
+    end: 7,
+    author: 'william',
+    body: 'It may help to name this value as the number of tickets left after both deductions.',
+    when: '3 min ago',
+    replies: [],
   },
 ];
 
@@ -46,6 +55,10 @@ function lineFromNode(node: Node | null): number | null {
   if (!line) return null;
   const parsed = Number(line);
   return Number.isFinite(parsed) ? parsed : null;
+}
+
+function lineLabel(range: LineRange): string {
+  return range.start === range.end ? `Line ${range.start}` : `Lines ${range.start}–${range.end}`;
 }
 
 export function CommentableCode({
@@ -61,19 +74,37 @@ export function CommentableCode({
   const codeAreaRef = useRef<HTMLDivElement>(null);
   const [comments, setComments] = useState<MockComment[]>(INITIAL_COMMENTS);
   const [selection, setSelection] = useState<LineRange | null>(null);
-  const [activeCommentId, setActiveCommentId] = useState<number | null>(1);
+  const [activeCommentId, setActiveCommentId] = useState<number | null>(null);
   const [composing, setComposing] = useState(false);
   const [draft, setDraft] = useState('');
+  const [replyingToId, setReplyingToId] = useState<number | null>(null);
+  const [replyDraft, setReplyDraft] = useState('');
 
-  const activeComment = comments.find((comment) => comment.id === activeCommentId) ?? null;
   const lineCount = useMemo(() => Math.max(1, code.split('\n').length), [code]);
   const codeStyle = resolvedTheme === 'dark' ? oneDark : oneLight;
 
-  const selectedOrCommentedLine = (line: number) => {
-    if (selection && line >= selection.start && line <= selection.end) return true;
-    return (
-      commentsVisible && comments.some((comment) => line >= comment.start && line <= comment.end)
-    );
+  useEffect(() => {
+    if (commentsVisible) return;
+    setSelection(null);
+    setActiveCommentId(null);
+    setComposing(false);
+    setReplyingToId(null);
+    window.getSelection()?.removeAllRanges();
+  }, [commentsVisible]);
+
+  const commentForLine = (line: number) =>
+    comments.find((comment) => line >= comment.start && line <= comment.end);
+
+  const lineBackground = (line: number) => {
+    if (selection && line >= selection.start && line <= selection.end) {
+      return 'hsl(var(--brand-300) / 0.72)';
+    }
+
+    const comment = commentForLine(line);
+    if (!commentsVisible || !comment) return 'transparent';
+    return comment.id === activeCommentId
+      ? 'hsl(var(--brand-300) / 0.72)'
+      : 'hsl(var(--brand-300) / 0.34)';
   };
 
   const handleSelection = () => {
@@ -92,20 +123,26 @@ export function CommentableCode({
 
     const anchorLine = lineFromNode(browserSelection.anchorNode);
     const focusLine = lineFromNode(browserSelection.focusNode);
-    const quote = browserSelection.toString().trim();
-    if (anchorLine === null || focusLine === null || !quote) return;
+    if (anchorLine === null || focusLine === null || !browserSelection.toString().trim()) return;
 
     setSelection({
       start: Math.min(anchorLine, focusLine),
       end: Math.max(anchorLine, focusLine),
-      quote: quote.slice(0, 180),
     });
     setActiveCommentId(null);
     setComposing(false);
+    setReplyingToId(null);
   };
 
-  const openComposer = (range: LineRange) => {
-    setSelection(range);
+  const activateComment = (id: number) => {
+    setActiveCommentId(id);
+    setSelection(null);
+    setComposing(false);
+    setReplyingToId(null);
+    window.getSelection()?.removeAllRanges();
+  };
+
+  const openComposer = () => {
     setActiveCommentId(null);
     setComposing(true);
     setDraft('');
@@ -119,6 +156,7 @@ export function CommentableCode({
       author: 'you',
       body: draft.trim(),
       when: 'just now',
+      replies: [],
     };
     setComments((current) => [...current, comment]);
     setActiveCommentId(comment.id);
@@ -128,16 +166,33 @@ export function CommentableCode({
     window.getSelection()?.removeAllRanges();
   };
 
-  const closeThread = () => {
-    setActiveCommentId(null);
+  const cancelComposer = () => {
     setComposing(false);
     setSelection(null);
+    setDraft('');
     window.getSelection()?.removeAllRanges();
   };
 
+  const addReply = (commentId: number) => {
+    if (!replyDraft.trim()) return;
+    setComments((current) =>
+      current.map((comment) =>
+        comment.id === commentId
+          ? { ...comment, replies: [...comment.replies, replyDraft.trim()] }
+          : comment
+      )
+    );
+    setReplyingToId(null);
+    setReplyDraft('');
+  };
+
   return (
-    <div className="relative size-full min-h-0 overflow-hidden bg-surface-100">
-      <div ref={codeAreaRef} onMouseUp={handleSelection} className="absolute inset-0 overflow-auto">
+    <div className="flex size-full min-h-0 overflow-hidden bg-surface-100">
+      <div
+        ref={codeAreaRef}
+        onMouseUp={handleSelection}
+        className="relative min-w-0 flex-1 overflow-auto"
+      >
         <SyntaxHighlighter
           language={language}
           style={codeStyle}
@@ -151,56 +206,36 @@ export function CommentableCode({
             background: 'transparent',
             fontSize: '13px',
             lineHeight: '20px',
-            padding: '16px 52px 16px 16px',
+            padding: '16px 48px 16px 16px',
           }}
           codeTagProps={{ style: { background: 'transparent' } }}
           lineNumberStyle={{ minWidth: '2.75em', paddingRight: '1em', opacity: 0.45 }}
           lineProps={(lineNumber) => ({
             'data-code-line': lineNumber,
+            onClick: () => {
+              const browserSelection = window.getSelection();
+              if (browserSelection && !browserSelection.isCollapsed) return;
+              const comment = commentForLine(lineNumber);
+              if (commentsVisible && comment) activateComment(comment.id);
+            },
             style: {
               display: 'block',
               minWidth: 'max-content',
-              background: selectedOrCommentedLine(lineNumber)
-                ? 'hsl(var(--brand-300) / 0.45)'
-                : 'transparent',
+              cursor: commentsVisible && commentForLine(lineNumber) ? 'pointer' : 'text',
+              background: lineBackground(lineNumber),
             },
           })}
         >
           {code || '// No solution code available'}
         </SyntaxHighlighter>
 
-        {commentsVisible &&
-          comments.map((comment, index) => (
-            <button
-              key={comment.id}
-              type="button"
-              onClick={() => {
-                setActiveCommentId(comment.id);
-                setSelection(null);
-                setComposing(false);
-              }}
-              className={`absolute right-2 z-10 flex size-6 items-center justify-center rounded-full border text-[11px] font-semibold shadow-sm transition-colors ${
-                activeCommentId === comment.id
-                  ? 'border-brand-highlight bg-brand-500 text-white'
-                  : 'border-border-strong bg-surface-100 text-brand hover:border-brand-highlight'
-              }`}
-              style={{ top: `${16 + (Math.min(comment.start, lineCount) - 1) * 20}px` }}
-              aria-label={`Open comment on lines ${comment.start} to ${comment.end}`}
-              title={`Comment on line${comment.start === comment.end ? '' : 's'} ${comment.start}${
-                comment.start === comment.end ? '' : `–${comment.end}`
-              }`}
-            >
-              {index + 1}
-            </button>
-          ))}
-
         {commentsVisible && selection && !composing && (
           <button
             type="button"
-            onClick={() => openComposer(selection)}
+            onClick={openComposer}
             className="absolute right-2 z-20 flex size-7 items-center justify-center rounded-full border border-brand-highlight bg-brand-500 text-white shadow-md hover:brightness-110"
             style={{ top: `${16 + (Math.min(selection.start, lineCount) - 1) * 20}px` }}
-            aria-label="Comment on selected code"
+            aria-label={`Comment on ${lineLabel(selection).toLowerCase()}`}
             title="Add comment"
           >
             <PlusIcon width="15" height="15" />
@@ -208,65 +243,110 @@ export function CommentableCode({
         )}
       </div>
 
-      {commentsVisible && !selection && !activeComment && !composing && (
-        <div className="pointer-events-none absolute right-3 top-3 rounded-md border border-border-default bg-surface-100/95 px-2.5 py-1.5 text-[11px] text-foreground-lighter shadow-sm">
-          Select code to add a comment
-        </div>
-      )}
+      {commentsVisible && (
+        <aside
+          className="w-[min(17rem,42%)] min-w-52 shrink-0 overflow-y-auto border-l border-border-default bg-background p-2"
+          aria-label="Inline comments"
+        >
+          <div className="space-y-2">
+            {comments.map((comment) => {
+              const active = comment.id === activeCommentId;
+              const replying = comment.id === replyingToId;
 
-      {commentsVisible && (activeComment || composing) && (
-        <aside className="absolute right-3 top-3 z-30 w-[min(19rem,calc(100%-1.5rem))] rounded-lg border border-border-strong bg-surface-100 shadow-xl">
-          <div className="flex items-center justify-between border-b border-border-default px-3 py-2">
-            <div className="flex items-center gap-2 text-xs font-medium text-foreground">
-              <ChatBubbleIcon width="14" height="14" className="text-brand" />
-              {composing
-                ? `New comment · line${selection?.start === selection?.end ? '' : 's'} ${
-                    selection?.start
-                  }${selection?.start === selection?.end ? '' : `–${selection?.end}`}`
-                : `Line${activeComment?.start === activeComment?.end ? '' : 's'} ${
-                    activeComment?.start
-                  }${activeComment?.start === activeComment?.end ? '' : `–${activeComment?.end}`}`}
-            </div>
-            <button
-              type="button"
-              onClick={closeThread}
-              className="rounded p-1 text-foreground-lighter hover:bg-surface-200 hover:text-foreground"
-              aria-label="Close comment"
-            >
-              <Cross2Icon width="14" height="14" />
-            </button>
-          </div>
-
-          <div className="p-3">
-            <blockquote className="mb-3 border-l-2 border-brand-400 pl-2 text-[11px] leading-relaxed text-foreground-lighter">
-              {composing ? selection?.quote : activeComment?.quote}
-            </blockquote>
-
-            {activeComment && !composing ? (
-              <div>
-                <div className="mb-1 flex items-baseline justify-between gap-2">
-                  <span className="text-xs font-semibold text-foreground">
-                    @{activeComment.author}
-                  </span>
-                  <span className="text-[10px] text-foreground-lighter">{activeComment.when}</span>
-                </div>
-                <p className="text-xs leading-relaxed text-foreground-light">
-                  {activeComment.body}
-                </p>
-                <button
-                  type="button"
-                  onClick={() => {
-                    setSelection(activeComment);
-                    setComposing(true);
-                    setDraft('');
-                  }}
-                  className="mt-3 text-xs font-medium text-brand hover:underline"
+              return (
+                <article
+                  key={comment.id}
+                  onClick={() => activateComment(comment.id)}
+                  className={`cursor-pointer rounded-lg border p-3 transition-colors ${
+                    active
+                      ? 'border-brand-highlight bg-surface-200 shadow-sm'
+                      : 'border-border-default bg-surface-100 hover:border-border-strong'
+                  }`}
                 >
-                  Reply
-                </button>
-              </div>
-            ) : (
-              <div className="space-y-2">
+                  <div className="mb-2 flex items-baseline justify-between gap-2">
+                    <span className="text-xs font-semibold text-foreground">@{comment.author}</span>
+                    <span className="shrink-0 text-[10px] text-foreground-lighter">
+                      {comment.when}
+                    </span>
+                  </div>
+                  <p className="text-xs leading-relaxed text-foreground-light">{comment.body}</p>
+
+                  {comment.replies.map((reply, index) => (
+                    <div
+                      key={`${comment.id}-reply-${index}`}
+                      className="mt-3 border-l-2 border-border-strong pl-2"
+                    >
+                      <span className="text-[11px] font-semibold text-foreground">@you</span>
+                      <p className="mt-0.5 text-xs leading-relaxed text-foreground-light">
+                        {reply}
+                      </p>
+                    </div>
+                  ))}
+
+                  {replying ? (
+                    <div className="mt-3 space-y-2" onClick={(event) => event.stopPropagation()}>
+                      <textarea
+                        value={replyDraft}
+                        onChange={(event) => setReplyDraft(event.target.value)}
+                        placeholder="Reply…"
+                        autoFocus
+                        rows={2}
+                        className="w-full resize-none rounded-md border border-border-strong bg-background px-2.5 py-2 text-xs text-foreground placeholder:text-foreground-lighter focus:border-brand-highlight focus:outline-none"
+                      />
+                      <div className="flex justify-end gap-2">
+                        <Button
+                          type="default"
+                          size="tiny"
+                          onClick={() => {
+                            setReplyingToId(null);
+                            setReplyDraft('');
+                          }}
+                        >
+                          Cancel
+                        </Button>
+                        <Button
+                          type="primary"
+                          size="tiny"
+                          onClick={() => addReply(comment.id)}
+                          disabled={!replyDraft.trim()}
+                        >
+                          Reply
+                        </Button>
+                      </div>
+                    </div>
+                  ) : (
+                    <button
+                      type="button"
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        activateComment(comment.id);
+                        setReplyingToId(comment.id);
+                        setReplyDraft('');
+                      }}
+                      className="mt-2 text-xs font-medium text-brand hover:underline"
+                    >
+                      Reply
+                    </button>
+                  )}
+                </article>
+              );
+            })}
+
+            {composing && selection && (
+              <article className="rounded-lg border border-brand-highlight bg-surface-100 p-3 shadow-sm">
+                <div className="mb-2 flex items-center justify-between gap-2">
+                  <span className="text-xs font-semibold text-foreground">
+                    New comment · {lineLabel(selection)}
+                  </span>
+                  <button
+                    type="button"
+                    onClick={cancelComposer}
+                    className="rounded p-1 text-foreground-lighter hover:bg-surface-200 hover:text-foreground"
+                    aria-label="Cancel comment"
+                  >
+                    <Cross2Icon width="13" height="13" />
+                  </button>
+                </div>
                 <textarea
                   value={draft}
                   onChange={(event) => setDraft(event.target.value)}
@@ -275,19 +355,16 @@ export function CommentableCode({
                   rows={3}
                   className="w-full resize-none rounded-md border border-border-strong bg-background px-2.5 py-2 text-xs text-foreground placeholder:text-foreground-lighter focus:border-brand-highlight focus:outline-none"
                 />
-                <div className="flex justify-end gap-2">
-                  <Button type="default" size="tiny" onClick={closeThread}>
+                <div className="mt-2 flex justify-end gap-2">
+                  <Button type="default" size="tiny" onClick={cancelComposer}>
                     Cancel
                   </Button>
                   <Button type="primary" size="tiny" onClick={addComment} disabled={!draft.trim()}>
                     Comment
                   </Button>
                 </div>
-              </div>
+              </article>
             )}
-          </div>
-          <div className="border-t border-border-default px-3 py-2 text-[10px] text-foreground-lighter">
-            Preview only · comments are not saved
           </div>
         </aside>
       )}

--- a/website/app/contest/[contestYear]/[problemCode]/new-solution-preview/CommentableCode.tsx
+++ b/website/app/contest/[contestYear]/[problemCode]/new-solution-preview/CommentableCode.tsx
@@ -51,6 +51,12 @@ function rangeLabel(code: string, range: TextRange): string {
   return first === last ? `Line ${first}` : `Lines ${first}–${last}`;
 }
 
+function commentTarget(code: string, range: TextRange): TextRange {
+  if (range.end > range.start || code.length === 0) return range;
+  const start = Math.min(range.start, code.length - 1);
+  return { start, end: start + 1 };
+}
+
 function fallbackRange(code: string, preferredLine: number): TextRange {
   const lines = code.split('\n');
   const lineIndex = clamp(preferredLine - 1, 0, Math.max(0, lines.length - 1));
@@ -228,8 +234,9 @@ export function CommentableCode({
     setActiveCommentId(null);
     setReplyingToId(null);
     setDraft('');
+    setTarget((current) => commentTarget(code, current));
     setComposing(true);
-  }, [composerRequest]);
+  }, [code, composerRequest]);
 
   useEffect(() => {
     const root = codeAreaRef.current;
@@ -403,8 +410,9 @@ export function CommentableCode({
 
   const addComment = () => {
     if (!draft.trim()) return;
+    const range = commentTarget(code, target);
     const comment: MockComment = {
-      ...target,
+      ...range,
       id: Date.now(),
       author: 'you',
       body: draft.trim(),
@@ -412,6 +420,7 @@ export function CommentableCode({
       replies: [],
     };
     setComments((current) => [comment, ...current]);
+    setTarget(range);
     setActiveCommentId(comment.id);
     setComposing(false);
     setDraft('');

--- a/website/app/contest/[contestYear]/[problemCode]/new-solution-preview/CommentableCode.tsx
+++ b/website/app/contest/[contestYear]/[problemCode]/new-solution-preview/CommentableCode.tsx
@@ -1,0 +1,296 @@
+'use client';
+
+import React, { useMemo, useRef, useState } from 'react';
+import dynamic from 'next/dynamic';
+import { useTheme } from 'next-themes';
+import { ChatBubbleIcon, Cross2Icon, PlusIcon } from '@radix-ui/react-icons';
+import { oneDark, oneLight } from 'react-syntax-highlighter/dist/esm/styles/prism';
+import { Button } from '../../../../../components/ui/button';
+
+const SyntaxHighlighter = dynamic(
+  () => import('react-syntax-highlighter').then((mod) => mod.Prism),
+  {
+    ssr: false,
+    loading: () => <div className="p-4 text-sm text-foreground-lighter">Loading code…</div>,
+  }
+);
+
+type LineRange = {
+  start: number;
+  end: number;
+  quote: string;
+};
+
+type MockComment = LineRange & {
+  id: number;
+  author: string;
+  body: string;
+  when: string;
+};
+
+const INITIAL_COMMENTS: MockComment[] = [
+  {
+    id: 1,
+    start: 4,
+    end: 5,
+    quote: 'This branch decides whether the remaining tickets are enough.',
+    author: 'mnop',
+    body: 'Could we mention why this comparison is sufficient? It took me a second to connect it to the problem statement.',
+    when: '8 min ago',
+  },
+];
+
+function lineFromNode(node: Node | null): number | null {
+  const element = node instanceof Element ? node : node?.parentElement;
+  const line = element?.closest('[data-code-line]')?.getAttribute('data-code-line');
+  if (!line) return null;
+  const parsed = Number(line);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+export function CommentableCode({
+  code,
+  language,
+  commentsVisible,
+}: {
+  code: string;
+  language: string;
+  commentsVisible: boolean;
+}) {
+  const { resolvedTheme } = useTheme();
+  const codeAreaRef = useRef<HTMLDivElement>(null);
+  const [comments, setComments] = useState<MockComment[]>(INITIAL_COMMENTS);
+  const [selection, setSelection] = useState<LineRange | null>(null);
+  const [activeCommentId, setActiveCommentId] = useState<number | null>(1);
+  const [composing, setComposing] = useState(false);
+  const [draft, setDraft] = useState('');
+
+  const activeComment = comments.find((comment) => comment.id === activeCommentId) ?? null;
+  const lineCount = useMemo(() => Math.max(1, code.split('\n').length), [code]);
+  const codeStyle = resolvedTheme === 'dark' ? oneDark : oneLight;
+
+  const selectedOrCommentedLine = (line: number) => {
+    if (selection && line >= selection.start && line <= selection.end) return true;
+    return (
+      commentsVisible && comments.some((comment) => line >= comment.start && line <= comment.end)
+    );
+  };
+
+  const handleSelection = () => {
+    if (!commentsVisible) return;
+    const browserSelection = window.getSelection();
+    if (
+      !browserSelection ||
+      browserSelection.isCollapsed ||
+      !browserSelection.anchorNode ||
+      !browserSelection.focusNode ||
+      !codeAreaRef.current?.contains(browserSelection.anchorNode) ||
+      !codeAreaRef.current.contains(browserSelection.focusNode)
+    ) {
+      return;
+    }
+
+    const anchorLine = lineFromNode(browserSelection.anchorNode);
+    const focusLine = lineFromNode(browserSelection.focusNode);
+    const quote = browserSelection.toString().trim();
+    if (anchorLine === null || focusLine === null || !quote) return;
+
+    setSelection({
+      start: Math.min(anchorLine, focusLine),
+      end: Math.max(anchorLine, focusLine),
+      quote: quote.slice(0, 180),
+    });
+    setActiveCommentId(null);
+    setComposing(false);
+  };
+
+  const openComposer = (range: LineRange) => {
+    setSelection(range);
+    setActiveCommentId(null);
+    setComposing(true);
+    setDraft('');
+  };
+
+  const addComment = () => {
+    if (!selection || !draft.trim()) return;
+    const comment: MockComment = {
+      ...selection,
+      id: Date.now(),
+      author: 'you',
+      body: draft.trim(),
+      when: 'just now',
+    };
+    setComments((current) => [...current, comment]);
+    setActiveCommentId(comment.id);
+    setSelection(null);
+    setComposing(false);
+    setDraft('');
+    window.getSelection()?.removeAllRanges();
+  };
+
+  const closeThread = () => {
+    setActiveCommentId(null);
+    setComposing(false);
+    setSelection(null);
+    window.getSelection()?.removeAllRanges();
+  };
+
+  return (
+    <div className="relative size-full min-h-0 overflow-hidden bg-surface-100">
+      <div ref={codeAreaRef} onMouseUp={handleSelection} className="absolute inset-0 overflow-auto">
+        <SyntaxHighlighter
+          language={language}
+          style={codeStyle}
+          showLineNumbers
+          wrapLines
+          wrapLongLines={false}
+          customStyle={{
+            minHeight: '100%',
+            margin: 0,
+            borderRadius: 0,
+            background: 'transparent',
+            fontSize: '13px',
+            lineHeight: '20px',
+            padding: '16px 52px 16px 16px',
+          }}
+          codeTagProps={{ style: { background: 'transparent' } }}
+          lineNumberStyle={{ minWidth: '2.75em', paddingRight: '1em', opacity: 0.45 }}
+          lineProps={(lineNumber) => ({
+            'data-code-line': lineNumber,
+            style: {
+              display: 'block',
+              minWidth: 'max-content',
+              background: selectedOrCommentedLine(lineNumber)
+                ? 'hsl(var(--brand-300) / 0.45)'
+                : 'transparent',
+            },
+          })}
+        >
+          {code || '// No solution code available'}
+        </SyntaxHighlighter>
+
+        {commentsVisible &&
+          comments.map((comment, index) => (
+            <button
+              key={comment.id}
+              type="button"
+              onClick={() => {
+                setActiveCommentId(comment.id);
+                setSelection(null);
+                setComposing(false);
+              }}
+              className={`absolute right-2 z-10 flex size-6 items-center justify-center rounded-full border text-[11px] font-semibold shadow-sm transition-colors ${
+                activeCommentId === comment.id
+                  ? 'border-brand-highlight bg-brand-500 text-white'
+                  : 'border-border-strong bg-surface-100 text-brand hover:border-brand-highlight'
+              }`}
+              style={{ top: `${16 + (Math.min(comment.start, lineCount) - 1) * 20}px` }}
+              aria-label={`Open comment on lines ${comment.start} to ${comment.end}`}
+              title={`Comment on line${comment.start === comment.end ? '' : 's'} ${comment.start}${
+                comment.start === comment.end ? '' : `–${comment.end}`
+              }`}
+            >
+              {index + 1}
+            </button>
+          ))}
+
+        {commentsVisible && selection && !composing && (
+          <button
+            type="button"
+            onClick={() => openComposer(selection)}
+            className="absolute right-2 z-20 flex size-7 items-center justify-center rounded-full border border-brand-highlight bg-brand-500 text-white shadow-md hover:brightness-110"
+            style={{ top: `${16 + (Math.min(selection.start, lineCount) - 1) * 20}px` }}
+            aria-label="Comment on selected code"
+            title="Add comment"
+          >
+            <PlusIcon width="15" height="15" />
+          </button>
+        )}
+      </div>
+
+      {commentsVisible && !selection && !activeComment && !composing && (
+        <div className="pointer-events-none absolute right-3 top-3 rounded-md border border-border-default bg-surface-100/95 px-2.5 py-1.5 text-[11px] text-foreground-lighter shadow-sm">
+          Select code to add a comment
+        </div>
+      )}
+
+      {commentsVisible && (activeComment || composing) && (
+        <aside className="absolute right-3 top-3 z-30 w-[min(19rem,calc(100%-1.5rem))] rounded-lg border border-border-strong bg-surface-100 shadow-xl">
+          <div className="flex items-center justify-between border-b border-border-default px-3 py-2">
+            <div className="flex items-center gap-2 text-xs font-medium text-foreground">
+              <ChatBubbleIcon width="14" height="14" className="text-brand" />
+              {composing
+                ? `New comment · line${selection?.start === selection?.end ? '' : 's'} ${
+                    selection?.start
+                  }${selection?.start === selection?.end ? '' : `–${selection?.end}`}`
+                : `Line${activeComment?.start === activeComment?.end ? '' : 's'} ${
+                    activeComment?.start
+                  }${activeComment?.start === activeComment?.end ? '' : `–${activeComment?.end}`}`}
+            </div>
+            <button
+              type="button"
+              onClick={closeThread}
+              className="rounded p-1 text-foreground-lighter hover:bg-surface-200 hover:text-foreground"
+              aria-label="Close comment"
+            >
+              <Cross2Icon width="14" height="14" />
+            </button>
+          </div>
+
+          <div className="p-3">
+            <blockquote className="mb-3 border-l-2 border-brand-400 pl-2 text-[11px] leading-relaxed text-foreground-lighter">
+              {composing ? selection?.quote : activeComment?.quote}
+            </blockquote>
+
+            {activeComment && !composing ? (
+              <div>
+                <div className="mb-1 flex items-baseline justify-between gap-2">
+                  <span className="text-xs font-semibold text-foreground">
+                    @{activeComment.author}
+                  </span>
+                  <span className="text-[10px] text-foreground-lighter">{activeComment.when}</span>
+                </div>
+                <p className="text-xs leading-relaxed text-foreground-light">
+                  {activeComment.body}
+                </p>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setSelection(activeComment);
+                    setComposing(true);
+                    setDraft('');
+                  }}
+                  className="mt-3 text-xs font-medium text-brand hover:underline"
+                >
+                  Reply
+                </button>
+              </div>
+            ) : (
+              <div className="space-y-2">
+                <textarea
+                  value={draft}
+                  onChange={(event) => setDraft(event.target.value)}
+                  placeholder="Add a comment…"
+                  autoFocus
+                  rows={3}
+                  className="w-full resize-none rounded-md border border-border-strong bg-background px-2.5 py-2 text-xs text-foreground placeholder:text-foreground-lighter focus:border-brand-highlight focus:outline-none"
+                />
+                <div className="flex justify-end gap-2">
+                  <Button type="default" size="tiny" onClick={closeThread}>
+                    Cancel
+                  </Button>
+                  <Button type="primary" size="tiny" onClick={addComment} disabled={!draft.trim()}>
+                    Comment
+                  </Button>
+                </div>
+              </div>
+            )}
+          </div>
+          <div className="border-t border-border-default px-3 py-2 text-[10px] text-foreground-lighter">
+            Preview only · comments are not saved
+          </div>
+        </aside>
+      )}
+    </div>
+  );
+}

--- a/website/app/contest/[contestYear]/[problemCode]/new-solution-preview/CommentableCode.tsx
+++ b/website/app/contest/[contestYear]/[problemCode]/new-solution-preview/CommentableCode.tsx
@@ -1,10 +1,9 @@
 'use client';
 
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useId, useMemo, useRef, useState } from 'react';
 import dynamic from 'next/dynamic';
 import { useTheme } from 'next-themes';
 import { ChevronRightIcon, Cross2Icon } from '@radix-ui/react-icons';
-import ReactMarkdown from 'react-markdown';
 import { oneDark, oneLight } from 'react-syntax-highlighter/dist/esm/styles/prism';
 import { Button } from '../../../../../components/ui/button';
 
@@ -87,19 +86,19 @@ function findLastRange(code: string, patterns: RegExp[], fallbackLine: number): 
 function initialComments(code: string): MockComment[] {
   return [
     {
-      id: 1,
-      ...findRange(code, [/t\s*-\s*p\s*<\s*b/i, /\(?T\s*-\s*P\s*-\s*B\)?\s*>=\s*0/i], 6),
-      author: 'mnop',
-      body: 'Could we mention why **this comparison** is sufficient? It took me a second to connect it to the problem statement.',
-      when: '8 min ago',
-      replies: [],
-    },
-    {
       id: 2,
       ...findLastRange(code, [/t\s*-\s*p\s*-\s*b/i, /T\s*-\s*P\s*-\s*B/i], 7),
       author: 'william',
       body: 'It may help to name this value as the number of tickets left after both deductions.',
       when: '3 min ago',
+      replies: [],
+    },
+    {
+      id: 1,
+      ...findRange(code, [/t\s*-\s*p\s*<\s*b/i, /\(?T\s*-\s*P\s*-\s*B\)?\s*>=\s*0/i], 6),
+      author: 'mnop',
+      body: 'Could we mention why this comparison is sufficient? It took me a second to connect it to the problem statement.',
+      when: '8 min ago',
       replies: [],
     },
   ];
@@ -165,11 +164,9 @@ function domRangeForText(root: HTMLElement, code: string, range: TextRange): Ran
   return domRange;
 }
 
-function CommentMarkdown({ children }: { children: string }) {
+function CommentBody({ children }: { children: string }) {
   return (
-    <div className="text-xs leading-relaxed text-foreground-light [&_a]:text-brand [&_a:hover]:underline [&_code]:rounded [&_code]:bg-surface-200 [&_code]:px-1 [&_ol]:list-decimal [&_ol]:pl-4 [&_p]:m-0 [&_pre]:overflow-x-auto [&_strong]:font-semibold [&_ul]:list-disc [&_ul]:pl-4">
-      <ReactMarkdown>{children}</ReactMarkdown>
-    </div>
+    <p className="whitespace-pre-wrap text-xs leading-relaxed text-foreground-light">{children}</p>
   );
 }
 
@@ -191,6 +188,15 @@ export function CommentableCode({
   onRailWidthChange: (width: number) => void;
 }) {
   const { resolvedTheme } = useTheme();
+  const highlightId = useId().replace(/[^a-zA-Z0-9_-]/g, '');
+  const highlightNames = useMemo(
+    () => ({
+      comments: `ccc-comments-${highlightId}`,
+      active: `ccc-comment-active-${highlightId}`,
+      target: `ccc-comment-target-${highlightId}`,
+    }),
+    [highlightId]
+  );
   const workspaceRef = useRef<HTMLDivElement>(null);
   const codeAreaRef = useRef<HTMLDivElement>(null);
   const handledComposerRequest = useRef(composerRequest);
@@ -201,16 +207,6 @@ export function CommentableCode({
   const [draft, setDraft] = useState('');
   const [replyingToId, setReplyingToId] = useState<number | null>(null);
   const [replyDraft, setReplyDraft] = useState('');
-  const [highlightRects, setHighlightRects] = useState<
-    Array<{
-      key: string;
-      left: number;
-      top: number;
-      width: number;
-      height: number;
-      active: boolean;
-    }>
-  >([]);
   const [caretRect, setCaretRect] = useState<{
     left: number;
     top: number;
@@ -238,40 +234,53 @@ export function CommentableCode({
   useEffect(() => {
     const root = codeAreaRef.current;
     if (!root) return;
+    const registry = (
+      CSS as typeof CSS & {
+        highlights?: {
+          set: (name: string, highlight: unknown) => void;
+          delete: (name: string) => void;
+        };
+      }
+    ).highlights;
+    const HighlightConstructor = (
+      window as typeof window & { Highlight?: new (...ranges: Range[]) => unknown }
+    ).Highlight;
     let frame = 0;
 
-    const measure = () => {
-      const rootRect = root.getBoundingClientRect();
-      const nextHighlights: typeof highlightRects = [];
-      const ranges: Array<{ key: string; range: TextRange; active: boolean }> = commentsVisible
-        ? comments.map((comment) => ({
-            key: `comment-${comment.id}`,
-            range: comment,
-            active: comment.id === activeCommentId,
-          }))
-        : [];
+    const updateDecorations = () => {
+      if (registry && HighlightConstructor) {
+        const regular = commentsVisible
+          ? comments
+              .filter((comment) => comment.id !== activeCommentId)
+              .map((comment) => domRangeForText(root, code, comment))
+              .filter((range): range is Range => range !== null)
+          : [];
+        const active = commentsVisible
+          ? comments
+              .filter((comment) => comment.id === activeCommentId)
+              .map((comment) => domRangeForText(root, code, comment))
+              .filter((range): range is Range => range !== null)
+          : [];
+        const targetRange =
+          target.end > target.start && activeCommentId === null
+            ? domRangeForText(root, code, target)
+            : null;
 
-      if (target.end > target.start && activeCommentId === null) {
-        ranges.push({ key: 'target', range: target, active: true });
+        registry.delete(highlightNames.comments);
+        registry.delete(highlightNames.active);
+        registry.delete(highlightNames.target);
+        if (regular.length) {
+          registry.set(highlightNames.comments, new HighlightConstructor(...regular));
+        }
+        if (active.length) {
+          registry.set(highlightNames.active, new HighlightConstructor(...active));
+        }
+        if (targetRange) {
+          registry.set(highlightNames.target, new HighlightConstructor(targetRange));
+        }
       }
 
-      ranges.forEach(({ key, range, active }) => {
-        const domRange = domRangeForText(root, code, range);
-        if (!domRange) return;
-        Array.from(domRange.getClientRects()).forEach((rect, index) => {
-          if (rect.width <= 0 || rect.height <= 0) return;
-          nextHighlights.push({
-            key: `${key}-${index}`,
-            left: rect.left - rootRect.left + root.scrollLeft,
-            top: rect.top - rootRect.top + root.scrollTop,
-            width: rect.width,
-            height: rect.height,
-            active,
-          });
-        });
-      });
-      setHighlightRects(nextHighlights);
-
+      const rootRect = root.getBoundingClientRect();
       const caretPoint = domPointForOffset(root, code, target.end);
       if (!caretPoint) {
         setCaretRect(null);
@@ -303,11 +312,11 @@ export function CommentableCode({
       });
     };
 
-    const scheduleMeasure = () => {
+    const scheduleUpdate = () => {
       window.cancelAnimationFrame(frame);
-      frame = window.requestAnimationFrame(measure);
+      frame = window.requestAnimationFrame(updateDecorations);
     };
-    const resizeObserver = new ResizeObserver(scheduleMeasure);
+    const resizeObserver = new ResizeObserver(scheduleUpdate);
     const mutationObserver = new MutationObserver((mutations) => {
       const codeChanged = mutations.some((mutation) =>
         Array.from(mutation.addedNodes).some(
@@ -316,20 +325,23 @@ export function CommentableCode({
             (node.matches('[data-code-line]') || node.querySelector('[data-code-line]'))
         )
       );
-      if (codeChanged) scheduleMeasure();
+      if (codeChanged) scheduleUpdate();
     });
     resizeObserver.observe(root);
     mutationObserver.observe(root, { childList: true, subtree: true });
-    window.addEventListener('resize', scheduleMeasure);
-    scheduleMeasure();
+    window.addEventListener('resize', scheduleUpdate);
+    scheduleUpdate();
 
     return () => {
       window.cancelAnimationFrame(frame);
       resizeObserver.disconnect();
       mutationObserver.disconnect();
-      window.removeEventListener('resize', scheduleMeasure);
+      window.removeEventListener('resize', scheduleUpdate);
+      registry?.delete(highlightNames.comments);
+      registry?.delete(highlightNames.active);
+      registry?.delete(highlightNames.target);
     };
-  }, [activeCommentId, code, comments, commentsVisible, target]);
+  }, [activeCommentId, code, comments, commentsVisible, highlightNames, target]);
 
   const handleSelection = (event: React.MouseEvent<HTMLDivElement>) => {
     const browserSelection = window.getSelection();
@@ -377,6 +389,7 @@ export function CommentableCode({
     );
     setActiveCommentId(commentsVisible ? (comment?.id ?? null) : null);
     setReplyingToId(null);
+    browserSelection?.removeAllRanges();
   };
 
   const activateComment = (id: number) => {
@@ -398,7 +411,7 @@ export function CommentableCode({
       when: 'just now',
       replies: [],
     };
-    setComments((current) => [...current, comment]);
+    setComments((current) => [comment, ...current]);
     setActiveCommentId(comment.id);
     setComposing(false);
     setDraft('');
@@ -447,30 +460,34 @@ export function CommentableCode({
 
   return (
     <div ref={workspaceRef} className="flex size-full min-h-0 overflow-hidden bg-surface-100">
+      <style>{`
+        ::highlight(${highlightNames.comments}) {
+          background-color: hsl(var(--warning-600) / 0.28);
+        }
+        ::highlight(${highlightNames.active}),
+        ::highlight(${highlightNames.target}) {
+          background-color: hsl(var(--warning-600) / 0.48);
+        }
+        @keyframes ccc-comment-caret-flash {
+          0%, 49% { visibility: visible; }
+          50%, 100% { visibility: hidden; }
+        }
+      `}</style>
       <div
         ref={codeAreaRef}
         onMouseUp={handleSelection}
         className="relative min-w-0 flex-1 cursor-text overflow-auto"
       >
         <div className="pointer-events-none absolute inset-0 z-[2]" aria-hidden="true">
-          {highlightRects.map((rect) => (
-            <span
-              key={rect.key}
-              className={`absolute rounded-[2px] ${
-                rect.active ? 'bg-brand-400/50' : 'bg-brand-400/25'
-              }`}
-              style={{
-                left: rect.left,
-                top: rect.top,
-                width: rect.width,
-                height: rect.height,
-              }}
-            />
-          ))}
           {caretRect && (
             <span
-              className="absolute w-0.5 animate-pulse bg-brand-500"
-              style={{ left: caretRect.left, top: caretRect.top, height: caretRect.height }}
+              className="absolute w-0.5 bg-brand-500"
+              style={{
+                left: caretRect.left,
+                top: caretRect.top,
+                height: caretRect.height,
+                animation: 'ccc-comment-caret-flash 1s step-end infinite',
+              }}
             />
           )}
         </div>
@@ -495,10 +512,7 @@ export function CommentableCode({
           lineNumberStyle={{ minWidth: '2.75em', paddingRight: '1em', opacity: 0.45 }}
           lineProps={(lineNumber) => ({
             'data-code-line': lineNumber,
-            style: {
-              display: 'block',
-              minWidth: 'max-content',
-            },
+            style: {},
           })}
         >
           {code || '// No solution code available'}
@@ -574,21 +588,18 @@ export function CommentableCode({
                     rows={3}
                     className="w-full resize-none rounded-md border border-border-strong bg-background px-2.5 py-2 text-xs text-foreground placeholder:text-foreground-lighter focus:border-brand-highlight focus:outline-none"
                   />
-                  <div className="mt-2 flex items-center justify-between gap-2">
-                    <span className="text-[10px] text-foreground-lighter">Markdown supported</span>
-                    <div className="flex gap-2">
-                      <Button type="default" size="tiny" onClick={cancelComposer}>
-                        Cancel
-                      </Button>
-                      <Button
-                        type="primary"
-                        size="tiny"
-                        onClick={addComment}
-                        disabled={!draft.trim()}
-                      >
-                        Comment
-                      </Button>
-                    </div>
+                  <div className="mt-2 flex justify-end gap-2">
+                    <Button type="default" size="tiny" onClick={cancelComposer}>
+                      Cancel
+                    </Button>
+                    <Button
+                      type="primary"
+                      size="tiny"
+                      onClick={addComment}
+                      disabled={!draft.trim()}
+                    >
+                      Comment
+                    </Button>
                   </div>
                 </article>
               </div>
@@ -616,7 +627,7 @@ export function CommentableCode({
                         {comment.when}
                       </span>
                     </div>
-                    <CommentMarkdown>{comment.body}</CommentMarkdown>
+                    <CommentBody>{comment.body}</CommentBody>
 
                     {comment.replies.map((reply, index) => (
                       <div
@@ -625,7 +636,7 @@ export function CommentableCode({
                       >
                         <span className="text-[11px] font-semibold text-foreground">@you</span>
                         <div className="mt-0.5">
-                          <CommentMarkdown>{reply}</CommentMarkdown>
+                          <CommentBody>{reply}</CommentBody>
                         </div>
                       </div>
                     ))}

--- a/website/app/contest/[contestYear]/[problemCode]/new-solution-preview/SolutionPreviewClient.tsx
+++ b/website/app/contest/[contestYear]/[problemCode]/new-solution-preview/SolutionPreviewClient.tsx
@@ -1,0 +1,980 @@
+'use client';
+
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import Link from 'next/link';
+import { useParams } from 'next/navigation';
+import {
+  ArrowLeftIcon,
+  ChatBubbleIcon,
+  CodeIcon,
+  Cross2Icon,
+  DownloadIcon,
+  ExclamationTriangleIcon,
+  FileTextIcon,
+  InfoCircledIcon,
+  ReaderIcon,
+  ResetIcon,
+} from '@radix-ui/react-icons';
+import { Button } from '../../../../../components/ui/button';
+import { DownloadDialog } from '../../../../../components/contest/DownloadDialog';
+import { MarkdownPreview } from '../../../../../components/forum/MarkdownPreview';
+import { problems } from '../../../../../constants';
+import {
+  CONTEST_API_BASE,
+  contestDownloadUrl,
+  fetchContestList,
+  fetchContestPreview,
+  type ContestListResponse,
+  type ContestSolutionMeta,
+  type ContestTestMeta,
+} from '../../../../../lib/contest-api';
+import ProblemPageClient from '../ProblemPageClient';
+import { CommentableCode } from './CommentableCode';
+
+type ViewMode = 'classic' | 'new';
+type PanelName = 'editorial' | 'solution' | 'tests';
+type LoadState = 'idle' | 'loading' | 'success' | 'error';
+type ListState = 'loading' | 'invalid' | 'error' | 'ok';
+
+type SolutionEntry = ContestSolutionMeta & {
+  code: string;
+  language: string;
+};
+
+type TestCaseData = {
+  input: string | null;
+  output: string | null;
+};
+
+const LARGE_FILE_BYTES = 50 * 1024;
+const DEFAULT_LEFT_SIZE = 54;
+const DEFAULT_SOLUTION_SIZE = 64;
+
+const MOCK_EDITORIAL = [
+  '# Intuition',
+  '',
+  'This is placeholder editorial content for the layout preview. Imagine that the key observation is that every customer consumes one ticket until the supply is exhausted.',
+  '',
+  'The useful quantity to track is the number of tickets remaining after processing each request. Once that value would become negative, the current request cannot be fulfilled.',
+  '',
+  '$$\\text{remaining} = T - \\sum_{i=1}^{k} r_i$$',
+  '',
+  '# Approach',
+  '',
+  '1. Read the initial number of available tickets.',
+  '2. Process each request in order.',
+  '3. Subtract a request only when enough tickets remain.',
+  '4. Report the first request that cannot be fulfilled, or the final remaining amount.',
+  '',
+  '> Preview note: this prose is intentionally mocked. It exists to test hierarchy, scrolling, math, and code beside a real solution.',
+  '',
+  '# Complexity',
+  '',
+  '- Time complexity: $O(N)$',
+  '- Space complexity: $O(1)$',
+  '',
+  '# Implementation notes',
+  '',
+  'Keep the running total in an integer large enough for the stated constraints. The loop should preserve input order because the first unfulfilled request matters.',
+  '',
+  '```cpp',
+  'for (int request : requests) {',
+  '    if (request > remaining) break;',
+  '    remaining -= request;',
+  '}',
+  '```',
+  '',
+  'Lorem ipsum dolor sit amet, consectetur adipiscing elit. This final paragraph gives the preview enough length to demonstrate independent panel scrolling without pretending to be an official solution.',
+].join('\n');
+
+const clamp = (value: number, min: number, max: number) => Math.min(max, Math.max(min, value));
+
+const formatSize = (bytes: number) =>
+  bytes > 1024 * 1024
+    ? `${(bytes / (1024 * 1024)).toFixed(1)}MB`
+    : `${(bytes / 1024).toFixed(1)}KB`;
+
+const testFilePath = (test: ContestTestMeta, kind: 'in' | 'out') =>
+  `${test.sample ? 'tests/sample' : 'tests'}/${test.n}.${kind}`;
+
+function languageFromExtension(ext: string): string {
+  if (ext === 'py') return 'python';
+  if (ext === 'java') return 'java';
+  if (ext === 't') return 'turing';
+  return 'cpp';
+}
+
+function languageLabel(language: string): string {
+  if (language === 'cpp') return 'C++';
+  if (language === 'python') return 'Python';
+  if (language === 'java') return 'Java';
+  if (language === 'turing') return 'Turing';
+  return language.toUpperCase();
+}
+
+function difficultyClass(difficulty: string): string {
+  switch (difficulty.toLowerCase()) {
+    case 'easy':
+      return 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300';
+    case 'normal':
+      return 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300';
+    case 'hard':
+      return 'bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-300';
+    case 'insane':
+      return 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300';
+    case 'wicked':
+      return 'bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-300';
+    default:
+      return 'bg-surface-200 text-foreground-light';
+  }
+}
+
+export default function SolutionPreviewClient() {
+  const [view, setView] = useState<ViewMode>('new');
+
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <div className="border-b border-border-default bg-surface-100">
+        <div className="mx-auto flex min-h-11 max-w-[1800px] items-center justify-between gap-3 px-4 py-1.5 sm:px-6 lg:px-8">
+          <div className="min-w-0">
+            <span className="text-xs font-medium text-foreground-light">
+              Solution layout preview
+            </span>
+            <span className="ml-2 hidden text-[11px] text-foreground-lighter sm:inline">
+              Frontend-only experiment
+            </span>
+          </div>
+          <div
+            className="inline-flex shrink-0 rounded-md border border-border-default bg-background p-0.5"
+            aria-label="Solution page layout"
+          >
+            {(['classic', 'new'] as const).map((option) => (
+              <button
+                key={option}
+                type="button"
+                onClick={() => setView(option)}
+                aria-pressed={view === option}
+                className={`rounded px-3 py-1 text-xs font-medium transition-colors ${
+                  view === option
+                    ? 'bg-brand-500 text-white'
+                    : 'text-foreground-light hover:bg-surface-200 hover:text-foreground'
+                }`}
+              >
+                {option === 'classic' ? 'Classic' : 'New'}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {view === 'classic' ? <ProblemPageClient /> : <WorkspaceView />}
+    </div>
+  );
+}
+
+function WorkspaceView() {
+  const { contestYear, problemCode } = useParams<{
+    contestYear: string;
+    problemCode: string;
+  }>();
+  const problemInfo = useMemo(
+    () => problems.find((problem) => problem.link === `/contest/${contestYear}/${problemCode}`),
+    [contestYear, problemCode]
+  );
+
+  const [listState, setListState] = useState<ListState>('loading');
+  const [tests, setTests] = useState<ContestTestMeta[]>([]);
+  const [solutions, setSolutions] = useState<ContestSolutionMeta[]>([]);
+  const [activeSolutionIndex, setActiveSolutionIndex] = useState<number | null>(null);
+  const [activeTestIndex, setActiveTestIndex] = useState<number | null>(null);
+  const [solutionEntry, setSolutionEntry] = useState<SolutionEntry | null>(null);
+  const [solutionState, setSolutionState] = useState<LoadState>('idle');
+  const [testData, setTestData] = useState<TestCaseData>({ input: '', output: '' });
+  const [testState, setTestState] = useState<LoadState>('idle');
+  const [downloadOpen, setDownloadOpen] = useState(false);
+  const [commentsVisible, setCommentsVisible] = useState(true);
+  const [visible, setVisible] = useState<Record<PanelName, boolean>>({
+    editorial: true,
+    solution: true,
+    tests: true,
+  });
+  const [leftSize, setLeftSize] = useState(DEFAULT_LEFT_SIZE);
+  const [solutionSize, setSolutionSize] = useState(DEFAULT_SOLUTION_SIZE);
+  const [mobilePanel, setMobilePanel] = useState<PanelName>('editorial');
+  const desktopRef = useRef<HTMLDivElement>(null);
+  const rightColumnRef = useRef<HTMLDivElement>(null);
+
+  const activeSolution =
+    activeSolutionIndex === null ? null : (solutions[activeSolutionIndex] ?? null);
+  const activeTest = activeTestIndex === null ? null : (tests[activeTestIndex] ?? null);
+  const rightVisible = visible.solution || visible.tests;
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    const loadList = async () => {
+      setListState('loading');
+      setTests([]);
+      setSolutions([]);
+      setActiveSolutionIndex(null);
+      setActiveTestIndex(null);
+      try {
+        const response = await fetchContestList(contestYear, problemCode, controller.signal);
+        if (response.status === 400) {
+          setListState('invalid');
+          return;
+        }
+        if (!response.ok) throw new Error(`list ${response.status}`);
+        const data = (await response.json()) as ContestListResponse;
+        const orderedTests = [...(data.tests ?? [])].sort(
+          (a, b) => Number(b.sample) - Number(a.sample) || a.n - b.n
+        );
+        const orderedSolutions = [...(data.solutions ?? [])].sort((a, b) => a.n - b.n);
+        setTests(orderedTests);
+        setSolutions(orderedSolutions);
+        setActiveSolutionIndex(orderedSolutions.length ? 0 : null);
+        setActiveTestIndex(orderedTests.length ? 0 : null);
+        setListState('ok');
+      } catch (error) {
+        if (controller.signal.aborted) return;
+        console.error('Error loading contest data:', error);
+        setListState('error');
+      }
+    };
+
+    loadList();
+    return () => controller.abort();
+  }, [contestYear, problemCode]);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    if (!activeSolution) {
+      setSolutionEntry(null);
+      setSolutionState('idle');
+      return () => controller.abort();
+    }
+
+    const loadSolution = async () => {
+      setSolutionState('loading');
+      setSolutionEntry(null);
+      try {
+        const response = await fetchContestPreview(
+          contestYear,
+          problemCode,
+          `solutions/${activeSolution.n}.${activeSolution.ext}`,
+          controller.signal
+        );
+        if (!response.ok) throw new Error(`solution ${response.status}`);
+        const code = await response.text();
+        if (controller.signal.aborted) return;
+        setSolutionEntry({
+          ...activeSolution,
+          code,
+          language: languageFromExtension(activeSolution.ext),
+        });
+        setSolutionState('success');
+      } catch (error) {
+        if (controller.signal.aborted) return;
+        console.error('Error loading solution:', error);
+        setSolutionState('error');
+      }
+    };
+
+    loadSolution();
+    return () => controller.abort();
+  }, [activeSolution, contestYear, problemCode]);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    if (!activeTest) {
+      setTestData({ input: '', output: '' });
+      setTestState('idle');
+      return () => controller.abort();
+    }
+
+    const loadTest = async () => {
+      setTestState('loading');
+      setTestData({ input: '', output: '' });
+      try {
+        const [inputResponse, outputResponse] = await Promise.all([
+          fetchContestPreview(
+            contestYear,
+            problemCode,
+            testFilePath(activeTest, 'in'),
+            controller.signal
+          ),
+          fetchContestPreview(
+            contestYear,
+            problemCode,
+            testFilePath(activeTest, 'out'),
+            controller.signal
+          ),
+        ]);
+        if (controller.signal.aborted) return;
+        if (!inputResponse.ok && !outputResponse.ok) {
+          setTestData({ input: null, output: null });
+          setTestState('error');
+          return;
+        }
+        setTestData({
+          input: inputResponse.ok ? await inputResponse.text() : null,
+          output: outputResponse.ok ? await outputResponse.text() : null,
+        });
+        setTestState('success');
+      } catch (error) {
+        if (controller.signal.aborted) return;
+        console.error('Error loading test case:', error);
+        setTestData({ input: null, output: null });
+        setTestState('error');
+      }
+    };
+
+    loadTest();
+    return () => controller.abort();
+  }, [activeTest, contestYear, problemCode]);
+
+  const togglePanel = (panel: PanelName) => {
+    setVisible((current) => ({ ...current, [panel]: !current[panel] }));
+  };
+
+  const resetLayout = () => {
+    setVisible({ editorial: true, solution: true, tests: true });
+    setLeftSize(DEFAULT_LEFT_SIZE);
+    setSolutionSize(DEFAULT_SOLUTION_SIZE);
+    setMobilePanel('editorial');
+  };
+
+  const startResize = (
+    axis: 'vertical' | 'horizontal',
+    event: React.PointerEvent<HTMLButtonElement>
+  ) => {
+    event.preventDefault();
+    const container = axis === 'vertical' ? desktopRef.current : rightColumnRef.current;
+    if (!container) return;
+    const rect = container.getBoundingClientRect();
+    const previousUserSelect = document.body.style.userSelect;
+    document.body.style.userSelect = 'none';
+
+    const move = (pointerEvent: PointerEvent) => {
+      if (axis === 'vertical') {
+        setLeftSize(clamp(((pointerEvent.clientX - rect.left) / rect.width) * 100, 28, 72));
+      } else {
+        setSolutionSize(clamp(((pointerEvent.clientY - rect.top) / rect.height) * 100, 30, 78));
+      }
+    };
+    const stop = () => {
+      document.body.style.userSelect = previousUserSelect;
+      window.removeEventListener('pointermove', move);
+      window.removeEventListener('pointerup', stop);
+    };
+
+    window.addEventListener('pointermove', move);
+    window.addEventListener('pointerup', stop);
+  };
+
+  const editorialPanel = <EditorialPanel onClose={() => togglePanel('editorial')} showClose />;
+  const solutionPanel = (
+    <SolutionPanel
+      listState={listState}
+      solutions={solutions}
+      activeSolutionIndex={activeSolutionIndex}
+      onSolutionChange={setActiveSolutionIndex}
+      solution={solutionEntry}
+      solutionState={solutionState}
+      contestYear={contestYear}
+      problemCode={problemCode}
+      commentsVisible={commentsVisible}
+      onToggleComments={() => setCommentsVisible((current) => !current)}
+      onClose={() => togglePanel('solution')}
+      showClose
+    />
+  );
+  const testsPanel = (
+    <TestsPanel
+      listState={listState}
+      tests={tests}
+      activeTestIndex={activeTestIndex}
+      onTestChange={setActiveTestIndex}
+      activeTest={activeTest}
+      testData={testData}
+      testState={testState}
+      onDownload={() => setDownloadOpen(true)}
+      onClose={() => togglePanel('tests')}
+      showClose
+    />
+  );
+
+  return (
+    <div className="flex min-h-[calc(100dvh-var(--nav-h)-2.75rem)] flex-col bg-background lg:h-[calc(100dvh-var(--nav-h)-2.75rem)] lg:min-h-[680px]">
+      <header className="shrink-0 border-b border-border-default bg-background px-4 py-4 sm:px-6 lg:px-8">
+        <div className="mx-auto flex max-w-[1800px] flex-wrap items-center justify-between gap-4">
+          <div className="min-w-0">
+            <Link
+              href="/solutions"
+              className="mb-1.5 inline-flex items-center gap-1.5 text-xs text-foreground-lighter transition-colors hover:text-foreground"
+            >
+              <ArrowLeftIcon width="13" height="13" />
+              Back to solutions
+            </Link>
+            <div className="flex flex-wrap items-center gap-2.5">
+              <h1 className="truncate text-xl font-semibold tracking-tight text-foreground sm:text-2xl">
+                {problemInfo?.name || `${contestYear} ${problemCode.toUpperCase()}`}
+              </h1>
+              {problemInfo?.difficulty && (
+                <span
+                  className={`inline-flex items-center rounded-xs px-2.5 py-1 text-[11px] font-medium leading-none ${difficultyClass(
+                    problemInfo.difficulty
+                  )}`}
+                >
+                  {problemInfo.difficulty}
+                </span>
+              )}
+            </div>
+            {problemInfo?.tags?.length ? (
+              <div className="mt-2 flex flex-wrap gap-1.5">
+                {problemInfo.tags.map((tag) => (
+                  <span
+                    key={tag}
+                    className="rounded-xs border border-border-default bg-surface-200 px-2 py-0.5 text-[10px] font-medium text-foreground-light"
+                  >
+                    {tag}
+                  </span>
+                ))}
+              </div>
+            ) : null}
+          </div>
+
+          {(tests.length > 0 || solutions.length > 0) && (
+            <Button
+              type="default"
+              size="small"
+              iconLeft={<DownloadIcon width="14" height="14" />}
+              onClick={() => setDownloadOpen(true)}
+            >
+              Download
+            </Button>
+          )}
+        </div>
+      </header>
+
+      <div className="hidden shrink-0 items-center justify-between gap-3 border-b border-border-default bg-surface-100 px-4 py-2 lg:flex lg:px-8">
+        <div className="flex items-center gap-1.5">
+          <span className="mr-1 text-[11px] text-foreground-lighter">Panels</span>
+          {(
+            [
+              ['editorial', 'Editorial'],
+              ['solution', 'Solution'],
+              ['tests', 'Test cases'],
+            ] as const
+          ).map(([panel, label]) => (
+            <button
+              key={panel}
+              type="button"
+              onClick={() => togglePanel(panel)}
+              aria-pressed={visible[panel]}
+              className={`rounded-md border px-2.5 py-1 text-[11px] font-medium transition-colors ${
+                visible[panel]
+                  ? 'border-brand-400 bg-brand-200 text-brand-600 dark:text-brand'
+                  : 'border-border-default bg-background text-foreground-lighter hover:text-foreground'
+              }`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+        <button
+          type="button"
+          onClick={resetLayout}
+          className="inline-flex items-center gap-1.5 rounded px-2 py-1 text-[11px] text-foreground-light hover:bg-surface-200 hover:text-foreground"
+        >
+          <ResetIcon width="12" height="12" />
+          Reset layout
+        </button>
+      </div>
+
+      <div ref={desktopRef} className="hidden min-h-0 flex-1 p-3 lg:flex">
+        {!visible.editorial && !rightVisible ? (
+          <div className="flex flex-1 items-center justify-center rounded-lg border border-dashed border-border-strong text-sm text-foreground-lighter">
+            Reopen a panel from the toolbar above.
+          </div>
+        ) : (
+          <>
+            {visible.editorial && (
+              <div
+                className="min-w-0 overflow-hidden rounded-lg border border-border-default bg-surface-100"
+                style={{ width: rightVisible ? `${leftSize}%` : '100%' }}
+              >
+                {editorialPanel}
+              </div>
+            )}
+
+            {visible.editorial && rightVisible && (
+              <ResizeHandle
+                orientation="vertical"
+                value={leftSize}
+                onPointerDown={(event) => startResize('vertical', event)}
+                onChange={(delta) => setLeftSize((current) => clamp(current + delta, 28, 72))}
+              />
+            )}
+
+            {rightVisible && (
+              <div ref={rightColumnRef} className="flex min-h-0 min-w-0 flex-1 flex-col">
+                {visible.solution && (
+                  <div
+                    className="min-h-0 overflow-hidden rounded-lg border border-border-default bg-surface-100"
+                    style={{ height: visible.tests ? `${solutionSize}%` : '100%' }}
+                  >
+                    {solutionPanel}
+                  </div>
+                )}
+
+                {visible.solution && visible.tests && (
+                  <ResizeHandle
+                    orientation="horizontal"
+                    value={solutionSize}
+                    onPointerDown={(event) => startResize('horizontal', event)}
+                    onChange={(delta) =>
+                      setSolutionSize((current) => clamp(current + delta, 30, 78))
+                    }
+                  />
+                )}
+
+                {visible.tests && (
+                  <div className="min-h-0 flex-1 overflow-hidden rounded-lg border border-border-default bg-surface-100">
+                    {testsPanel}
+                  </div>
+                )}
+              </div>
+            )}
+          </>
+        )}
+      </div>
+
+      <div className="flex min-h-[70dvh] flex-1 flex-col lg:hidden">
+        <div className="flex shrink-0 overflow-x-auto border-b border-border-default bg-surface-100 px-3">
+          {(
+            [
+              ['editorial', 'Editorial'],
+              ['solution', 'Solution'],
+              ['tests', 'Test cases'],
+            ] as const
+          ).map(([panel, label]) => (
+            <button
+              key={panel}
+              type="button"
+              onClick={() => setMobilePanel(panel)}
+              className={`border-b-2 px-4 py-3 text-sm font-medium whitespace-nowrap ${
+                mobilePanel === panel
+                  ? 'border-brand-500 text-brand'
+                  : 'border-transparent text-foreground-light'
+              }`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+        <div className="min-h-0 flex-1 bg-surface-100">
+          {mobilePanel === 'editorial' && <EditorialPanel showClose={false} />}
+          {mobilePanel === 'solution' && (
+            <SolutionPanel
+              listState={listState}
+              solutions={solutions}
+              activeSolutionIndex={activeSolutionIndex}
+              onSolutionChange={setActiveSolutionIndex}
+              solution={solutionEntry}
+              solutionState={solutionState}
+              contestYear={contestYear}
+              problemCode={problemCode}
+              commentsVisible={commentsVisible}
+              onToggleComments={() => setCommentsVisible((current) => !current)}
+              showClose={false}
+            />
+          )}
+          {mobilePanel === 'tests' && (
+            <TestsPanel
+              listState={listState}
+              tests={tests}
+              activeTestIndex={activeTestIndex}
+              onTestChange={setActiveTestIndex}
+              activeTest={activeTest}
+              testData={testData}
+              testState={testState}
+              onDownload={() => setDownloadOpen(true)}
+              showClose={false}
+            />
+          )}
+        </div>
+      </div>
+
+      <DownloadDialog
+        open={downloadOpen}
+        onClose={() => setDownloadOpen(false)}
+        apiBase={CONTEST_API_BASE}
+        year={contestYear}
+        code={problemCode}
+        tests={tests}
+        solutions={solutions}
+      />
+    </div>
+  );
+}
+
+function PanelHeader({
+  icon,
+  title,
+  children,
+  onClose,
+  showClose,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  children?: React.ReactNode;
+  onClose?: () => void;
+  showClose: boolean;
+}) {
+  return (
+    <div className="flex min-h-11 shrink-0 items-center justify-between gap-3 border-b border-border-default bg-surface-200 px-3">
+      <div className="flex min-w-0 items-center gap-2 text-xs font-semibold text-foreground">
+        <span className="text-brand">{icon}</span>
+        <span className="truncate">{title}</span>
+      </div>
+      <div className="flex min-w-0 items-center gap-1.5">
+        {children}
+        {showClose && onClose && (
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded p-1.5 text-foreground-lighter hover:bg-surface-300 hover:text-foreground"
+            aria-label={`Close ${title} panel`}
+            title={`Close ${title}`}
+          >
+            <Cross2Icon width="13" height="13" />
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function EditorialPanel({ onClose, showClose }: { onClose?: () => void; showClose: boolean }) {
+  return (
+    <section className="flex size-full min-h-0 flex-col" aria-label="Editorial">
+      <PanelHeader
+        icon={<ReaderIcon width="15" height="15" />}
+        title="Editorial"
+        onClose={onClose}
+        showClose={showClose}
+      >
+        <Button asChild type="primary" size="tiny">
+          <Link href="/create-post">Ask a question</Link>
+        </Button>
+      </PanelHeader>
+      <article className="min-h-0 flex-1 overflow-y-auto px-5 py-6 sm:px-7">
+        <div className="mb-5 rounded-md border border-brand-300 bg-brand-200 px-3 py-2 text-xs text-brand-600 dark:text-brand">
+          Preview editorial · placeholder content only
+        </div>
+        <div className="mx-auto max-w-3xl [&_h1]:mb-3 [&_h1]:mt-8 [&_h1]:text-xl [&_h1]:font-semibold [&_h1]:tracking-tight [&_h1]:text-foreground [&_h1:first-child]:mt-0 [&_blockquote]:rounded-r-md [&_blockquote]:border-l-2 [&_blockquote]:border-brand-400 [&_blockquote]:bg-surface-200 [&_blockquote]:px-3 [&_blockquote]:py-2">
+          <MarkdownPreview content={MOCK_EDITORIAL} />
+        </div>
+      </article>
+    </section>
+  );
+}
+
+function SolutionPanel({
+  listState,
+  solutions,
+  activeSolutionIndex,
+  onSolutionChange,
+  solution,
+  solutionState,
+  contestYear,
+  problemCode,
+  commentsVisible,
+  onToggleComments,
+  onClose,
+  showClose,
+}: {
+  listState: ListState;
+  solutions: ContestSolutionMeta[];
+  activeSolutionIndex: number | null;
+  onSolutionChange: (index: number) => void;
+  solution: SolutionEntry | null;
+  solutionState: LoadState;
+  contestYear: string;
+  problemCode: string;
+  commentsVisible: boolean;
+  onToggleComments: () => void;
+  onClose?: () => void;
+  showClose: boolean;
+}) {
+  return (
+    <section className="flex size-full min-h-0 flex-col" aria-label="Solution">
+      <PanelHeader
+        icon={<CodeIcon width="15" height="15" />}
+        title="Solution"
+        onClose={onClose}
+        showClose={showClose}
+      >
+        {solutions.length > 0 && activeSolutionIndex !== null && (
+          <select
+            value={activeSolutionIndex}
+            onChange={(event) => onSolutionChange(Number(event.target.value))}
+            className="h-7 max-w-36 rounded-md border border-border-strong bg-surface-100 px-2 text-[11px] text-foreground focus:border-brand-highlight focus:outline-none"
+            aria-label="Choose solution"
+          >
+            {solutions.map((entry, index) => (
+              <option key={`${entry.n}.${entry.ext}`} value={index}>
+                {index + 1} · {languageLabel(languageFromExtension(entry.ext))}
+              </option>
+            ))}
+          </select>
+        )}
+        <button
+          type="button"
+          onClick={onToggleComments}
+          aria-pressed={commentsVisible}
+          className={`inline-flex h-7 items-center gap-1 rounded-md border px-2 text-[11px] transition-colors ${
+            commentsVisible
+              ? 'border-brand-400 bg-brand-200 text-brand-600 dark:text-brand'
+              : 'border-border-strong bg-surface-100 text-foreground-lighter hover:text-foreground'
+          }`}
+          title="Toggle inline comments"
+        >
+          <ChatBubbleIcon width="12" height="12" />
+          <span className="hidden xl:inline">Comments</span>
+        </button>
+        {solution && (
+          <a
+            href={contestDownloadUrl(
+              contestYear,
+              problemCode,
+              `solutions/${solution.n}.${solution.ext}`
+            )}
+            className="rounded p-1.5 text-foreground-lighter hover:bg-surface-300 hover:text-brand"
+            aria-label="Download selected solution"
+            title="Download solution"
+          >
+            <DownloadIcon width="14" height="14" />
+          </a>
+        )}
+      </PanelHeader>
+
+      <div className="min-h-0 flex-1">
+        {listState === 'loading' || solutionState === 'loading' ? (
+          <PanelStatus label="Loading solution…" loading />
+        ) : listState === 'invalid' ? (
+          <PanelStatus label="This problem does not exist." />
+        ) : listState === 'error' || solutionState === 'error' ? (
+          <PanelStatus label="Unable to load solutions right now." error />
+        ) : solutions.length === 0 ? (
+          <PanelStatus label="No solution is available yet." />
+        ) : solution ? (
+          <CommentableCode
+            key={`${solution.n}.${solution.ext}`}
+            code={solution.code}
+            language={solution.language}
+            commentsVisible={commentsVisible}
+          />
+        ) : (
+          <PanelStatus label="Choose a solution to view its code." />
+        )}
+      </div>
+    </section>
+  );
+}
+
+function TestsPanel({
+  listState,
+  tests,
+  activeTestIndex,
+  onTestChange,
+  activeTest,
+  testData,
+  testState,
+  onDownload,
+  onClose,
+  showClose,
+}: {
+  listState: ListState;
+  tests: ContestTestMeta[];
+  activeTestIndex: number | null;
+  onTestChange: (index: number) => void;
+  activeTest: ContestTestMeta | null;
+  testData: TestCaseData;
+  testState: LoadState;
+  onDownload: () => void;
+  onClose?: () => void;
+  showClose: boolean;
+}) {
+  const largeFile =
+    activeTest && Math.max(activeTest.inputBytes, activeTest.outputBytes) > LARGE_FILE_BYTES;
+
+  return (
+    <section className="flex size-full min-h-0 flex-col" aria-label="Test cases">
+      <PanelHeader
+        icon={<FileTextIcon width="15" height="15" />}
+        title="Test cases"
+        onClose={onClose}
+        showClose={showClose}
+      >
+        {tests.length > 0 && (
+          <button
+            type="button"
+            onClick={onDownload}
+            className="rounded p-1.5 text-foreground-lighter hover:bg-surface-300 hover:text-brand"
+            aria-label="Download test cases"
+            title="Download test cases"
+          >
+            <DownloadIcon width="14" height="14" />
+          </button>
+        )}
+      </PanelHeader>
+
+      {tests.length > 0 && (
+        <div className="flex shrink-0 gap-1.5 overflow-x-auto border-b border-border-default bg-surface-100 px-3 py-2">
+          {tests.map((test, index) => (
+            <button
+              key={`${test.sample ? 'sample' : 'case'}-${test.n}`}
+              type="button"
+              onClick={() => onTestChange(index)}
+              className={`rounded-md px-2.5 py-1 text-[11px] font-medium whitespace-nowrap transition-colors ${
+                activeTestIndex === index
+                  ? 'bg-brand-500 text-white'
+                  : 'bg-surface-200 text-foreground-light hover:bg-surface-300 hover:text-foreground'
+              }`}
+            >
+              {test.sample ? `Sample ${test.n}` : `Case ${test.n}`}
+            </button>
+          ))}
+        </div>
+      )}
+
+      <div className="min-h-0 flex-1 overflow-auto p-3">
+        {listState === 'loading' || testState === 'loading' ? (
+          <PanelStatus label="Loading test case…" loading />
+        ) : listState === 'invalid' ? (
+          <PanelStatus label="This problem does not exist." />
+        ) : listState === 'error' ? (
+          <PanelStatus label="Unable to load test cases right now." error />
+        ) : tests.length === 0 ? (
+          <PanelStatus label="No test cases are available." />
+        ) : testState === 'error' ? (
+          <PanelStatus label="This test case could not be previewed." error />
+        ) : testState === 'success' && activeTest ? (
+          <div className="space-y-3">
+            {largeFile && (
+              <div className="flex items-start gap-2 rounded-md border border-warning-400 bg-warning-200 px-3 py-2 text-xs text-warning-600">
+                <ExclamationTriangleIcon width="13" height="13" className="mt-0.5 shrink-0" />
+                Preview is truncated because this is a large file. Download it for the full data.
+              </div>
+            )}
+            <div className="grid grid-cols-1 gap-3 xl:grid-cols-2">
+              <TestValue label="Input" bytes={activeTest.inputBytes} value={testData.input} />
+              <TestValue
+                label="Expected output"
+                bytes={activeTest.outputBytes}
+                value={testData.output}
+              />
+            </div>
+          </div>
+        ) : (
+          <PanelStatus label="Select a test case to view its input and output." />
+        )}
+      </div>
+    </section>
+  );
+}
+
+function TestValue({
+  label,
+  bytes,
+  value,
+}: {
+  label: string;
+  bytes: number;
+  value: string | null;
+}) {
+  return (
+    <div className="min-w-0">
+      <div className="mb-1.5 flex items-center justify-between gap-2">
+        <h3 className="text-[11px] font-medium text-foreground-light">{label}</h3>
+        <span className="text-[10px] text-foreground-lighter">{formatSize(bytes)}</span>
+      </div>
+      <pre className="min-h-24 overflow-auto rounded-md border border-border-strong bg-background p-2.5 font-mono text-xs leading-relaxed text-foreground">
+        {value ?? 'Unavailable'}
+      </pre>
+    </div>
+  );
+}
+
+function PanelStatus({
+  label,
+  loading = false,
+  error = false,
+}: {
+  label: string;
+  loading?: boolean;
+  error?: boolean;
+}) {
+  return (
+    <div
+      className={`flex size-full min-h-32 items-center justify-center gap-2 p-6 text-center text-sm ${
+        error ? 'text-destructive' : 'text-foreground-lighter'
+      }`}
+    >
+      {loading ? (
+        <span className="size-5 animate-spin rounded-full border-2 border-surface-300 border-t-brand" />
+      ) : error ? (
+        <ExclamationTriangleIcon width="16" height="16" />
+      ) : (
+        <InfoCircledIcon width="16" height="16" />
+      )}
+      <span>{label}</span>
+    </div>
+  );
+}
+
+function ResizeHandle({
+  orientation,
+  value,
+  onPointerDown,
+  onChange,
+}: {
+  orientation: 'vertical' | 'horizontal';
+  value: number;
+  onPointerDown: (event: React.PointerEvent<HTMLButtonElement>) => void;
+  onChange: (delta: number) => void;
+}) {
+  const vertical = orientation === 'vertical';
+
+  return (
+    <button
+      type="button"
+      role="separator"
+      aria-label={`Resize ${vertical ? 'editorial and solution' : 'solution and test case'} panels`}
+      aria-orientation={orientation}
+      aria-valuemin={vertical ? 28 : 30}
+      aria-valuemax={vertical ? 72 : 78}
+      aria-valuenow={Math.round(value)}
+      onPointerDown={onPointerDown}
+      onKeyDown={(event) => {
+        if (vertical && event.key === 'ArrowLeft') onChange(-2);
+        if (vertical && event.key === 'ArrowRight') onChange(2);
+        if (!vertical && event.key === 'ArrowUp') onChange(-2);
+        if (!vertical && event.key === 'ArrowDown') onChange(2);
+      }}
+      className={`group relative shrink-0 touch-none focus:outline-none ${
+        vertical ? 'w-3 cursor-col-resize' : 'h-3 cursor-row-resize'
+      }`}
+    >
+      <span
+        className={`absolute bg-border-strong transition-colors group-hover:bg-brand-400 group-focus:bg-brand-400 ${
+          vertical
+            ? 'inset-y-2 left-1/2 w-px -translate-x-1/2'
+            : 'inset-x-2 top-1/2 h-px -translate-y-1/2'
+        }`}
+      />
+    </button>
+  );
+}

--- a/website/app/contest/[contestYear]/[problemCode]/new-solution-preview/SolutionPreviewClient.tsx
+++ b/website/app/contest/[contestYear]/[problemCode]/new-solution-preview/SolutionPreviewClient.tsx
@@ -6,6 +6,8 @@ import { useParams } from 'next/navigation';
 import {
   ArrowLeftIcon,
   ChevronDownIcon,
+  ChevronLeftIcon,
+  ChevronRightIcon,
   ChevronUpIcon,
   CodeIcon,
   DownloadIcon,
@@ -52,6 +54,7 @@ type TestCaseData = {
 const LARGE_FILE_BYTES = 50 * 1024;
 const DEFAULT_LEFT_SIZE = 54;
 const DEFAULT_SOLUTION_SIZE = 64;
+const DEFAULT_COMMENT_SIZE = 272;
 const LAYOUT_STORAGE_KEY = 'cccsolutions-solution-layout-v1';
 const DEFAULT_MINIMIZED: MinimizedState = {
   editorial: false,
@@ -138,10 +141,12 @@ function LayoutControls({
   view,
   onViewChange,
   onReset,
+  showReset = true,
 }: {
   view: ViewMode;
   onViewChange: (view: ViewMode) => void;
   onReset: () => void;
+  showReset?: boolean;
 }) {
   return (
     <div className="flex shrink-0 items-center gap-2">
@@ -165,14 +170,16 @@ function LayoutControls({
           </button>
         ))}
       </div>
-      <button
-        type="button"
-        onClick={onReset}
-        className="inline-flex h-7 items-center gap-1.5 rounded-md px-2 text-[11px] text-foreground-light transition-colors hover:bg-surface-200 hover:text-foreground"
-      >
-        <ResetIcon width="12" height="12" />
-        Reset layout
-      </button>
+      {showReset && (
+        <button
+          type="button"
+          onClick={onReset}
+          className="inline-flex h-7 items-center gap-1.5 rounded-md px-2 text-[11px] text-foreground-light transition-colors hover:bg-surface-200 hover:text-foreground"
+        >
+          <ResetIcon width="12" height="12" />
+          Reset layout
+        </button>
+      )}
     </div>
   );
 }
@@ -187,7 +194,12 @@ export default function SolutionPreviewClient() {
   return view === 'classic' ? (
     <ProblemPageClient
       headerControls={
-        <LayoutControls view={view} onViewChange={setView} onReset={clearSavedLayout} />
+        <LayoutControls
+          view={view}
+          onViewChange={setView}
+          onReset={clearSavedLayout}
+          showReset={false}
+        />
       }
     />
   ) : (
@@ -226,6 +238,7 @@ function WorkspaceView({
   const [fullscreen, setFullscreen] = useState<PanelName | null>(null);
   const [leftSize, setLeftSize] = useState(DEFAULT_LEFT_SIZE);
   const [solutionSize, setSolutionSize] = useState(DEFAULT_SOLUTION_SIZE);
+  const [commentSize, setCommentSize] = useState(DEFAULT_COMMENT_SIZE);
   const [mobilePanel, setMobilePanel] = useState<PanelName>('editorial');
   const [layoutLoaded, setLayoutLoaded] = useState(false);
   const desktopRef = useRef<HTMLDivElement>(null);
@@ -242,6 +255,7 @@ function WorkspaceView({
         const layout = JSON.parse(saved) as {
           leftSize?: number;
           solutionSize?: number;
+          commentSize?: number;
           minimized?: Partial<MinimizedState>;
         };
         if (typeof layout.leftSize === 'number') {
@@ -250,8 +264,13 @@ function WorkspaceView({
         if (typeof layout.solutionSize === 'number') {
           setSolutionSize(clamp(layout.solutionSize, 30, 78));
         }
+        if (typeof layout.commentSize === 'number') {
+          setCommentSize(clamp(layout.commentSize, 176, 440));
+        }
         if (layout.minimized) {
-          setMinimized({ ...DEFAULT_MINIMIZED, ...layout.minimized });
+          const restored = { ...DEFAULT_MINIMIZED, ...layout.minimized };
+          if (restored.solution && restored.tests) restored.tests = false;
+          setMinimized(restored);
         }
       }
     } catch {
@@ -265,9 +284,9 @@ function WorkspaceView({
     if (!layoutLoaded) return;
     window.localStorage.setItem(
       LAYOUT_STORAGE_KEY,
-      JSON.stringify({ leftSize, solutionSize, minimized })
+      JSON.stringify({ leftSize, solutionSize, commentSize, minimized })
     );
-  }, [layoutLoaded, leftSize, minimized, solutionSize]);
+  }, [commentSize, layoutLoaded, leftSize, minimized, solutionSize]);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -395,7 +414,16 @@ function WorkspaceView({
 
   const toggleMinimized = (panel: PanelName) => {
     setFullscreen(null);
-    setMinimized((current) => ({ ...current, [panel]: !current[panel] }));
+    setMinimized((current) => {
+      const next = { ...current, [panel]: !current[panel] };
+
+      if (next.solution && next.tests) {
+        const otherPanel = panel === 'solution' ? 'tests' : 'solution';
+        next[otherPanel] = false;
+      }
+
+      return next;
+    });
   };
 
   const toggleFullscreen = (panel: PanelName) => {
@@ -408,6 +436,7 @@ function WorkspaceView({
     setFullscreen(null);
     setLeftSize(DEFAULT_LEFT_SIZE);
     setSolutionSize(DEFAULT_SOLUTION_SIZE);
+    setCommentSize(DEFAULT_COMMENT_SIZE);
     setMobilePanel('editorial');
     window.localStorage.removeItem(LAYOUT_STORAGE_KEY);
   };
@@ -467,6 +496,8 @@ function WorkspaceView({
       problemCode={problemCode}
       commentsVisible={commentsVisible}
       onToggleComments={() => setCommentsVisible((current) => !current)}
+      commentSize={commentSize}
+      onCommentSizeChange={setCommentSize}
       minimized={minimized.solution}
       fullscreen={fullscreen === 'solution'}
       onMinimize={() => toggleMinimized('solution')}
@@ -522,6 +553,7 @@ function WorkspaceView({
                 onChange={(delta) => setLeftSize((current) => clamp(current + delta, 28, 72))}
               />
             )}
+            {minimized.editorial && <div className="w-3 shrink-0" />}
 
             <div ref={rightColumnRef} className="flex min-h-0 min-w-0 flex-1 flex-col">
               <div
@@ -618,6 +650,8 @@ function WorkspaceView({
               problemCode={problemCode}
               commentsVisible={commentsVisible}
               onToggleComments={() => setCommentsVisible((current) => !current)}
+              commentSize={commentSize}
+              onCommentSizeChange={setCommentSize}
               minimized={false}
               fullscreen={false}
               onMinimize={() => undefined}
@@ -667,7 +701,7 @@ function PanelHeader({
   onMinimize,
   onFullscreen,
   showPanelControls,
-  hideTitleWhenMinimized = false,
+  minimizeIcon,
 }: {
   icon: React.ReactNode;
   title: string;
@@ -677,23 +711,19 @@ function PanelHeader({
   onMinimize: () => void;
   onFullscreen: () => void;
   showPanelControls: boolean;
-  hideTitleWhenMinimized?: boolean;
+  minimizeIcon?: React.ReactNode;
 }) {
   return (
-    <div
-      className={`group relative flex h-11 shrink-0 items-center border-b border-border-default bg-surface-200 ${
-        minimized && hideTitleWhenMinimized ? 'justify-center px-0' : 'justify-between gap-3 px-3'
-      }`}
-    >
+    <div className="group relative flex h-11 shrink-0 items-center justify-between gap-3 border-b border-border-default bg-surface-200 px-3">
       <div className="flex min-w-0 items-center gap-2 text-xs font-semibold text-foreground">
         <span className="shrink-0 text-brand">{icon}</span>
-        {(!minimized || !hideTitleWhenMinimized) && <span className="truncate">{title}</span>}
+        <span className="truncate">{title}</span>
       </div>
       {!minimized && (
         <div className="flex min-w-0 items-center gap-1.5">
           {children}
           {showPanelControls && (
-            <div className="flex items-center opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
+            <div className="flex items-center">
               <button
                 type="button"
                 onClick={onFullscreen}
@@ -714,20 +744,23 @@ function PanelHeader({
                 aria-label={`Minimize ${title} panel`}
                 title="Minimize"
               >
-                <ChevronDownIcon width="13" height="13" />
+                {minimizeIcon ?? <ChevronDownIcon width="13" height="13" />}
               </button>
             </div>
           )}
         </div>
       )}
       {minimized && showPanelControls && (
-        <div
-          className={`opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 ${
-            hideTitleWhenMinimized
-              ? 'absolute inset-0 flex items-center justify-center bg-surface-200'
-              : ''
-          }`}
-        >
+        <div className="flex items-center">
+          <button
+            type="button"
+            onClick={onFullscreen}
+            className="rounded p-1.5 text-foreground-lighter hover:bg-surface-300 hover:text-foreground"
+            aria-label={`Fullscreen ${title} panel`}
+            title="Fullscreen"
+          >
+            <EnterFullScreenIcon width="13" height="13" />
+          </button>
           <button
             type="button"
             onClick={onMinimize}
@@ -766,6 +799,48 @@ function EditorialPanel({
 }) {
   const title = problemInfo?.name || `${contestYear} ${problemCode.toUpperCase()}`;
 
+  if (minimized && showPanelControls) {
+    return (
+      <section
+        className="flex size-full min-h-0 flex-col items-center bg-surface-200 py-2"
+        aria-label="Editorial"
+      >
+        <button
+          type="button"
+          onClick={onMinimize}
+          className="flex min-h-0 flex-1 flex-col items-center gap-2 text-foreground-light transition-colors hover:text-foreground"
+          aria-label="Restore editorial panel"
+          title="Restore editorial"
+        >
+          <ReaderIcon width="16" height="16" className="shrink-0 text-brand" />
+          <span className="[writing-mode:vertical-rl] rotate-180 text-xs font-semibold tracking-wide">
+            Editorial
+          </span>
+        </button>
+        <div className="mt-auto flex flex-col items-center gap-1">
+          <button
+            type="button"
+            onClick={onFullscreen}
+            className="rounded p-2 text-foreground-lighter transition-colors hover:bg-surface-300 hover:text-foreground"
+            aria-label="Fullscreen editorial panel"
+            title="Fullscreen"
+          >
+            <EnterFullScreenIcon width="14" height="14" />
+          </button>
+          <button
+            type="button"
+            onClick={onMinimize}
+            className="rounded p-2 text-foreground-lighter transition-colors hover:bg-surface-300 hover:text-foreground"
+            aria-label="Restore editorial panel"
+            title="Restore"
+          >
+            <ChevronRightIcon width="15" height="15" />
+          </button>
+        </div>
+      </section>
+    );
+  }
+
   return (
     <section className="flex size-full min-h-0 flex-col" aria-label="Editorial">
       <PanelHeader
@@ -776,7 +851,7 @@ function EditorialPanel({
         onMinimize={onMinimize}
         onFullscreen={onFullscreen}
         showPanelControls={showPanelControls}
-        hideTitleWhenMinimized
+        minimizeIcon={<ChevronLeftIcon width="13" height="13" />}
       >
         {layoutControls}
       </PanelHeader>
@@ -815,7 +890,7 @@ function EditorialPanel({
                   ))}
                 </div>
               </div>
-              <Button asChild type="default" size="tiny">
+              <Button asChild type="primary" size="tiny">
                 <Link href="/create-post">Ask a question</Link>
               </Button>
             </div>
@@ -840,6 +915,8 @@ function SolutionPanel({
   problemCode,
   commentsVisible,
   onToggleComments,
+  commentSize,
+  onCommentSizeChange,
   minimized,
   fullscreen,
   onMinimize,
@@ -856,6 +933,8 @@ function SolutionPanel({
   problemCode: string;
   commentsVisible: boolean;
   onToggleComments: () => void;
+  commentSize: number;
+  onCommentSizeChange: (size: number) => void;
   minimized: boolean;
   fullscreen: boolean;
   onMinimize: () => void;
@@ -928,6 +1007,9 @@ function SolutionPanel({
               code={solution.code}
               language={solution.language}
               commentsVisible={commentsVisible}
+              onCloseComments={onToggleComments}
+              railWidth={commentSize}
+              onRailWidthChange={onCommentSizeChange}
             />
           ) : (
             <PanelStatus label="Choose a solution to view its code." />

--- a/website/app/contest/[contestYear]/[problemCode]/new-solution-preview/SolutionPreviewClient.tsx
+++ b/website/app/contest/[contestYear]/[problemCode]/new-solution-preview/SolutionPreviewClient.tsx
@@ -803,18 +803,18 @@ function EditorialPanel({
     return (
       <section
         className="flex size-full min-h-0 flex-col items-center bg-surface-200 py-2"
-        aria-label="Editorial"
+        aria-label={`${title} editorial`}
       >
         <button
           type="button"
           onClick={onMinimize}
           className="flex min-h-0 flex-1 flex-col items-center gap-2 text-foreground-light transition-colors hover:text-foreground"
-          aria-label="Restore editorial panel"
-          title="Restore editorial"
+          aria-label={`Restore ${title} editorial panel`}
+          title={`Restore ${title}`}
         >
           <ReaderIcon width="16" height="16" className="shrink-0 text-brand" />
           <span className="[writing-mode:vertical-rl] rotate-180 text-xs font-semibold tracking-wide">
-            Editorial
+            {title}
           </span>
         </button>
         <div className="mt-auto flex flex-col items-center gap-1">

--- a/website/app/contest/[contestYear]/[problemCode]/new-solution-preview/SolutionPreviewClient.tsx
+++ b/website/app/contest/[contestYear]/[problemCode]/new-solution-preview/SolutionPreviewClient.tsx
@@ -5,11 +5,13 @@ import Link from 'next/link';
 import { useParams } from 'next/navigation';
 import {
   ArrowLeftIcon,
-  ChatBubbleIcon,
+  ChevronDownIcon,
+  ChevronUpIcon,
   CodeIcon,
-  Cross2Icon,
   DownloadIcon,
+  EnterFullScreenIcon,
   ExclamationTriangleIcon,
+  ExitFullScreenIcon,
   FileTextIcon,
   InfoCircledIcon,
   ReaderIcon,
@@ -35,6 +37,7 @@ type ViewMode = 'classic' | 'new';
 type PanelName = 'editorial' | 'solution' | 'tests';
 type LoadState = 'idle' | 'loading' | 'success' | 'error';
 type ListState = 'loading' | 'invalid' | 'error' | 'ok';
+type MinimizedState = Record<PanelName, boolean>;
 
 type SolutionEntry = ContestSolutionMeta & {
   code: string;
@@ -49,42 +52,44 @@ type TestCaseData = {
 const LARGE_FILE_BYTES = 50 * 1024;
 const DEFAULT_LEFT_SIZE = 54;
 const DEFAULT_SOLUTION_SIZE = 64;
+const LAYOUT_STORAGE_KEY = 'cccsolutions-solution-layout-v1';
+const DEFAULT_MINIMIZED: MinimizedState = {
+  editorial: false,
+  solution: false,
+  tests: false,
+};
 
-const MOCK_EDITORIAL = [
+const EDITORIAL_CONTENT = [
   '# Intuition',
   '',
-  'This is placeholder editorial content for the layout preview. Imagine that the key observation is that every customer consumes one ticket until the supply is exhausted.',
+  'The key observation is that the final ticket count depends only on the two groups that already have tickets reserved. Subtract both values from the total capacity.',
   '',
-  'The useful quantity to track is the number of tickets remaining after processing each request. Once that value would become negative, the current request cannot be fulfilled.',
+  'If the remaining count is non-negative, everyone fits and that count is the number of unused tickets. Otherwise, the concert does not have enough tickets.',
   '',
-  '$$\\text{remaining} = T - \\sum_{i=1}^{k} r_i$$',
+  '$$\\text{remaining} = T - P - B$$',
   '',
   '# Approach',
   '',
-  '1. Read the initial number of available tickets.',
-  '2. Process each request in order.',
-  '3. Subtract a request only when enough tickets remain.',
-  '4. Report the first request that cannot be fulfilled, or the final remaining amount.',
-  '',
-  '> Preview note: this prose is intentionally mocked. It exists to test hierarchy, scrolling, math, and code beside a real solution.',
+  '1. Read the number of Bayview students, the ticket capacity, and the number of Portview students.',
+  '2. Compute `remaining = T - P - B`.',
+  '3. Print `Y` and the remaining count when the value is non-negative; otherwise print `N`.',
   '',
   '# Complexity',
   '',
-  '- Time complexity: $O(N)$',
+  '- Time complexity: $O(1)$',
   '- Space complexity: $O(1)$',
   '',
   '# Implementation notes',
   '',
-  'Keep the running total in an integer large enough for the stated constraints. The loop should preserve input order because the first unfulfilled request matters.',
+  'The comparison includes zero because filling every available seat is still a valid result.',
   '',
-  '```cpp',
-  'for (int request : requests) {',
-  '    if (request > remaining) break;',
-  '    remaining -= request;',
-  '}',
+  '```python',
+  'remaining = T - P - B',
+  'if remaining >= 0:',
+  '    print("Y", remaining)',
+  'else:',
+  '    print("N")',
   '```',
-  '',
-  'Lorem ipsum dolor sit amet, consectetur adipiscing elit. This final paragraph gives the preview enough length to demonstrate independent panel scrolling without pretending to be an official solution.',
 ].join('\n');
 
 const clamp = (value: number, min: number, max: number) => Math.min(max, Math.max(min, value));
@@ -129,50 +134,74 @@ function difficultyClass(difficulty: string): string {
   }
 }
 
-export default function SolutionPreviewClient() {
-  const [view, setView] = useState<ViewMode>('new');
-
+function LayoutControls({
+  view,
+  onViewChange,
+  onReset,
+}: {
+  view: ViewMode;
+  onViewChange: (view: ViewMode) => void;
+  onReset: () => void;
+}) {
   return (
-    <div className="min-h-screen bg-background text-foreground">
-      <div className="border-b border-border-default bg-surface-100">
-        <div className="mx-auto flex min-h-11 max-w-[1800px] items-center justify-between gap-3 px-4 py-1.5 sm:px-6 lg:px-8">
-          <div className="min-w-0">
-            <span className="text-xs font-medium text-foreground-light">
-              Solution layout preview
-            </span>
-            <span className="ml-2 hidden text-[11px] text-foreground-lighter sm:inline">
-              Frontend-only experiment
-            </span>
-          </div>
-          <div
-            className="inline-flex shrink-0 rounded-md border border-border-default bg-background p-0.5"
-            aria-label="Solution page layout"
+    <div className="flex shrink-0 items-center gap-2">
+      <div
+        className="inline-flex rounded-md border border-border-default bg-background p-0.5"
+        aria-label="Solution page layout"
+      >
+        {(['classic', 'new'] as const).map((option) => (
+          <button
+            key={option}
+            type="button"
+            onClick={() => onViewChange(option)}
+            aria-pressed={view === option}
+            className={`rounded px-2.5 py-1 text-[11px] font-medium transition-colors ${
+              view === option
+                ? 'bg-brand-500 text-white'
+                : 'text-foreground-light hover:bg-surface-200 hover:text-foreground'
+            }`}
           >
-            {(['classic', 'new'] as const).map((option) => (
-              <button
-                key={option}
-                type="button"
-                onClick={() => setView(option)}
-                aria-pressed={view === option}
-                className={`rounded px-3 py-1 text-xs font-medium transition-colors ${
-                  view === option
-                    ? 'bg-brand-500 text-white'
-                    : 'text-foreground-light hover:bg-surface-200 hover:text-foreground'
-                }`}
-              >
-                {option === 'classic' ? 'Classic' : 'New'}
-              </button>
-            ))}
-          </div>
-        </div>
+            {option === 'classic' ? 'Classic' : 'New'}
+          </button>
+        ))}
       </div>
-
-      {view === 'classic' ? <ProblemPageClient /> : <WorkspaceView />}
+      <button
+        type="button"
+        onClick={onReset}
+        className="inline-flex h-7 items-center gap-1.5 rounded-md px-2 text-[11px] text-foreground-light transition-colors hover:bg-surface-200 hover:text-foreground"
+      >
+        <ResetIcon width="12" height="12" />
+        Reset layout
+      </button>
     </div>
   );
 }
 
-function WorkspaceView() {
+export default function SolutionPreviewClient() {
+  const [view, setView] = useState<ViewMode>('new');
+
+  const clearSavedLayout = () => {
+    window.localStorage.removeItem(LAYOUT_STORAGE_KEY);
+  };
+
+  return view === 'classic' ? (
+    <ProblemPageClient
+      headerControls={
+        <LayoutControls view={view} onViewChange={setView} onReset={clearSavedLayout} />
+      }
+    />
+  ) : (
+    <WorkspaceView view={view} onViewChange={setView} />
+  );
+}
+
+function WorkspaceView({
+  view,
+  onViewChange,
+}: {
+  view: ViewMode;
+  onViewChange: (view: ViewMode) => void;
+}) {
   const { contestYear, problemCode } = useParams<{
     contestYear: string;
     problemCode: string;
@@ -193,21 +222,52 @@ function WorkspaceView() {
   const [testState, setTestState] = useState<LoadState>('idle');
   const [downloadOpen, setDownloadOpen] = useState(false);
   const [commentsVisible, setCommentsVisible] = useState(true);
-  const [visible, setVisible] = useState<Record<PanelName, boolean>>({
-    editorial: true,
-    solution: true,
-    tests: true,
-  });
+  const [minimized, setMinimized] = useState<MinimizedState>(DEFAULT_MINIMIZED);
+  const [fullscreen, setFullscreen] = useState<PanelName | null>(null);
   const [leftSize, setLeftSize] = useState(DEFAULT_LEFT_SIZE);
   const [solutionSize, setSolutionSize] = useState(DEFAULT_SOLUTION_SIZE);
   const [mobilePanel, setMobilePanel] = useState<PanelName>('editorial');
+  const [layoutLoaded, setLayoutLoaded] = useState(false);
   const desktopRef = useRef<HTMLDivElement>(null);
   const rightColumnRef = useRef<HTMLDivElement>(null);
 
   const activeSolution =
     activeSolutionIndex === null ? null : (solutions[activeSolutionIndex] ?? null);
   const activeTest = activeTestIndex === null ? null : (tests[activeTestIndex] ?? null);
-  const rightVisible = visible.solution || visible.tests;
+
+  useEffect(() => {
+    try {
+      const saved = window.localStorage.getItem(LAYOUT_STORAGE_KEY);
+      if (saved) {
+        const layout = JSON.parse(saved) as {
+          leftSize?: number;
+          solutionSize?: number;
+          minimized?: Partial<MinimizedState>;
+        };
+        if (typeof layout.leftSize === 'number') {
+          setLeftSize(clamp(layout.leftSize, 28, 72));
+        }
+        if (typeof layout.solutionSize === 'number') {
+          setSolutionSize(clamp(layout.solutionSize, 30, 78));
+        }
+        if (layout.minimized) {
+          setMinimized({ ...DEFAULT_MINIMIZED, ...layout.minimized });
+        }
+      }
+    } catch {
+      window.localStorage.removeItem(LAYOUT_STORAGE_KEY);
+    } finally {
+      setLayoutLoaded(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!layoutLoaded) return;
+    window.localStorage.setItem(
+      LAYOUT_STORAGE_KEY,
+      JSON.stringify({ leftSize, solutionSize, minimized })
+    );
+  }, [layoutLoaded, leftSize, minimized, solutionSize]);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -333,15 +393,23 @@ function WorkspaceView() {
     return () => controller.abort();
   }, [activeTest, contestYear, problemCode]);
 
-  const togglePanel = (panel: PanelName) => {
-    setVisible((current) => ({ ...current, [panel]: !current[panel] }));
+  const toggleMinimized = (panel: PanelName) => {
+    setFullscreen(null);
+    setMinimized((current) => ({ ...current, [panel]: !current[panel] }));
+  };
+
+  const toggleFullscreen = (panel: PanelName) => {
+    setMinimized((current) => ({ ...current, [panel]: false }));
+    setFullscreen((current) => (current === panel ? null : panel));
   };
 
   const resetLayout = () => {
-    setVisible({ editorial: true, solution: true, tests: true });
+    setMinimized(DEFAULT_MINIMIZED);
+    setFullscreen(null);
     setLeftSize(DEFAULT_LEFT_SIZE);
     setSolutionSize(DEFAULT_SOLUTION_SIZE);
     setMobilePanel('editorial');
+    window.localStorage.removeItem(LAYOUT_STORAGE_KEY);
   };
 
   const startResize = (
@@ -372,7 +440,21 @@ function WorkspaceView() {
     window.addEventListener('pointerup', stop);
   };
 
-  const editorialPanel = <EditorialPanel onClose={() => togglePanel('editorial')} showClose />;
+  const editorialPanel = (
+    <EditorialPanel
+      problemInfo={problemInfo}
+      contestYear={contestYear}
+      problemCode={problemCode}
+      layoutControls={
+        <LayoutControls view={view} onViewChange={onViewChange} onReset={resetLayout} />
+      }
+      minimized={minimized.editorial}
+      fullscreen={fullscreen === 'editorial'}
+      onMinimize={() => toggleMinimized('editorial')}
+      onFullscreen={() => toggleFullscreen('editorial')}
+      showPanelControls
+    />
+  );
   const solutionPanel = (
     <SolutionPanel
       listState={listState}
@@ -385,8 +467,11 @@ function WorkspaceView() {
       problemCode={problemCode}
       commentsVisible={commentsVisible}
       onToggleComments={() => setCommentsVisible((current) => !current)}
-      onClose={() => togglePanel('solution')}
-      showClose
+      minimized={minimized.solution}
+      fullscreen={fullscreen === 'solution'}
+      onMinimize={() => toggleMinimized('solution')}
+      onFullscreen={() => toggleFullscreen('solution')}
+      showPanelControls
     />
   );
   const testsPanel = (
@@ -399,116 +484,37 @@ function WorkspaceView() {
       testData={testData}
       testState={testState}
       onDownload={() => setDownloadOpen(true)}
-      onClose={() => togglePanel('tests')}
-      showClose
+      minimized={minimized.tests}
+      fullscreen={fullscreen === 'tests'}
+      onMinimize={() => toggleMinimized('tests')}
+      onFullscreen={() => toggleFullscreen('tests')}
+      showPanelControls
     />
   );
 
   return (
-    <div className="flex min-h-[calc(100dvh-var(--nav-h)-2.75rem)] flex-col bg-background lg:h-[calc(100dvh-var(--nav-h)-2.75rem)] lg:min-h-[680px]">
-      <header className="shrink-0 border-b border-border-default bg-background px-4 py-4 sm:px-6 lg:px-8">
-        <div className="mx-auto flex max-w-[1800px] flex-wrap items-center justify-between gap-4">
-          <div className="min-w-0">
-            <Link
-              href="/solutions"
-              className="mb-1.5 inline-flex items-center gap-1.5 text-xs text-foreground-lighter transition-colors hover:text-foreground"
-            >
-              <ArrowLeftIcon width="13" height="13" />
-              Back to solutions
-            </Link>
-            <div className="flex flex-wrap items-center gap-2.5">
-              <h1 className="truncate text-xl font-semibold tracking-tight text-foreground sm:text-2xl">
-                {problemInfo?.name || `${contestYear} ${problemCode.toUpperCase()}`}
-              </h1>
-              {problemInfo?.difficulty && (
-                <span
-                  className={`inline-flex items-center rounded-xs px-2.5 py-1 text-[11px] font-medium leading-none ${difficultyClass(
-                    problemInfo.difficulty
-                  )}`}
-                >
-                  {problemInfo.difficulty}
-                </span>
-              )}
-            </div>
-            {problemInfo?.tags?.length ? (
-              <div className="mt-2 flex flex-wrap gap-1.5">
-                {problemInfo.tags.map((tag) => (
-                  <span
-                    key={tag}
-                    className="rounded-xs border border-border-default bg-surface-200 px-2 py-0.5 text-[10px] font-medium text-foreground-light"
-                  >
-                    {tag}
-                  </span>
-                ))}
-              </div>
-            ) : null}
-          </div>
-
-          {(tests.length > 0 || solutions.length > 0) && (
-            <Button
-              type="default"
-              size="small"
-              iconLeft={<DownloadIcon width="14" height="14" />}
-              onClick={() => setDownloadOpen(true)}
-            >
-              Download
-            </Button>
-          )}
-        </div>
-      </header>
-
-      <div className="hidden shrink-0 items-center justify-between gap-3 border-b border-border-default bg-surface-100 px-4 py-2 lg:flex lg:px-8">
-        <div className="flex items-center gap-1.5">
-          <span className="mr-1 text-[11px] text-foreground-lighter">Panels</span>
-          {(
-            [
-              ['editorial', 'Editorial'],
-              ['solution', 'Solution'],
-              ['tests', 'Test cases'],
-            ] as const
-          ).map(([panel, label]) => (
-            <button
-              key={panel}
-              type="button"
-              onClick={() => togglePanel(panel)}
-              aria-pressed={visible[panel]}
-              className={`rounded-md border px-2.5 py-1 text-[11px] font-medium transition-colors ${
-                visible[panel]
-                  ? 'border-brand-400 bg-brand-200 text-brand-600 dark:text-brand'
-                  : 'border-border-default bg-background text-foreground-lighter hover:text-foreground'
-              }`}
-            >
-              {label}
-            </button>
-          ))}
-        </div>
-        <button
-          type="button"
-          onClick={resetLayout}
-          className="inline-flex items-center gap-1.5 rounded px-2 py-1 text-[11px] text-foreground-light hover:bg-surface-200 hover:text-foreground"
-        >
-          <ResetIcon width="12" height="12" />
-          Reset layout
-        </button>
-      </div>
-
+    <div className="mb-3 flex min-h-[70dvh] flex-col bg-background text-foreground lg:h-[calc(100dvh-var(--nav-h)-0.75rem)] lg:min-h-0">
       <div ref={desktopRef} className="hidden min-h-0 flex-1 p-3 lg:flex">
-        {!visible.editorial && !rightVisible ? (
-          <div className="flex flex-1 items-center justify-center rounded-lg border border-dashed border-border-strong text-sm text-foreground-lighter">
-            Reopen a panel from the toolbar above.
+        {fullscreen ? (
+          <div className="min-h-0 min-w-0 flex-1 overflow-hidden rounded-lg border border-border-default bg-surface-100">
+            {fullscreen === 'editorial'
+              ? editorialPanel
+              : fullscreen === 'solution'
+                ? solutionPanel
+                : testsPanel}
           </div>
         ) : (
           <>
-            {visible.editorial && (
-              <div
-                className="min-w-0 overflow-hidden rounded-lg border border-border-default bg-surface-100"
-                style={{ width: rightVisible ? `${leftSize}%` : '100%' }}
-              >
-                {editorialPanel}
-              </div>
-            )}
+            <div
+              className={`min-w-0 overflow-hidden rounded-lg border border-border-default bg-surface-100 ${
+                minimized.editorial ? 'shrink-0' : ''
+              }`}
+              style={{ width: minimized.editorial ? '44px' : `${leftSize}%` }}
+            >
+              {editorialPanel}
+            </div>
 
-            {visible.editorial && rightVisible && (
+            {!minimized.editorial && (
               <ResizeHandle
                 orientation="vertical"
                 value={leftSize}
@@ -517,40 +523,54 @@ function WorkspaceView() {
               />
             )}
 
-            {rightVisible && (
-              <div ref={rightColumnRef} className="flex min-h-0 min-w-0 flex-1 flex-col">
-                {visible.solution && (
-                  <div
-                    className="min-h-0 overflow-hidden rounded-lg border border-border-default bg-surface-100"
-                    style={{ height: visible.tests ? `${solutionSize}%` : '100%' }}
-                  >
-                    {solutionPanel}
-                  </div>
-                )}
-
-                {visible.solution && visible.tests && (
-                  <ResizeHandle
-                    orientation="horizontal"
-                    value={solutionSize}
-                    onPointerDown={(event) => startResize('horizontal', event)}
-                    onChange={(delta) =>
-                      setSolutionSize((current) => clamp(current + delta, 30, 78))
-                    }
-                  />
-                )}
-
-                {visible.tests && (
-                  <div className="min-h-0 flex-1 overflow-hidden rounded-lg border border-border-default bg-surface-100">
-                    {testsPanel}
-                  </div>
-                )}
+            <div ref={rightColumnRef} className="flex min-h-0 min-w-0 flex-1 flex-col">
+              <div
+                className={`overflow-hidden rounded-lg border border-border-default bg-surface-100 ${
+                  minimized.solution
+                    ? 'h-11 shrink-0'
+                    : minimized.tests
+                      ? 'min-h-0 flex-1'
+                      : 'min-h-0'
+                }`}
+                style={
+                  !minimized.solution && !minimized.tests
+                    ? { height: `${solutionSize}%` }
+                    : undefined
+                }
+              >
+                {solutionPanel}
               </div>
-            )}
+
+              {!minimized.solution && !minimized.tests ? (
+                <ResizeHandle
+                  orientation="horizontal"
+                  value={solutionSize}
+                  onPointerDown={(event) => startResize('horizontal', event)}
+                  onChange={(delta) => setSolutionSize((current) => clamp(current + delta, 30, 78))}
+                />
+              ) : (
+                <div className="h-3 shrink-0" />
+              )}
+
+              <div
+                className={`overflow-hidden rounded-lg border border-border-default bg-surface-100 ${
+                  minimized.tests ? 'h-11 shrink-0' : 'min-h-0 flex-1'
+                }`}
+              >
+                {testsPanel}
+              </div>
+            </div>
           </>
         )}
       </div>
 
       <div className="flex min-h-[70dvh] flex-1 flex-col lg:hidden">
+        <div className="flex shrink-0 items-center justify-between gap-3 border-b border-border-default bg-surface-100 px-3 py-2">
+          <span className="min-w-0 truncate text-xs font-semibold text-foreground">
+            {problemInfo?.name || `${contestYear} ${problemCode.toUpperCase()}`}
+          </span>
+          <LayoutControls view={view} onViewChange={onViewChange} onReset={resetLayout} />
+        </div>
         <div className="flex shrink-0 overflow-x-auto border-b border-border-default bg-surface-100 px-3">
           {(
             [
@@ -574,7 +594,18 @@ function WorkspaceView() {
           ))}
         </div>
         <div className="min-h-0 flex-1 bg-surface-100">
-          {mobilePanel === 'editorial' && <EditorialPanel showClose={false} />}
+          {mobilePanel === 'editorial' && (
+            <EditorialPanel
+              problemInfo={problemInfo}
+              contestYear={contestYear}
+              problemCode={problemCode}
+              minimized={false}
+              fullscreen={false}
+              onMinimize={() => undefined}
+              onFullscreen={() => undefined}
+              showPanelControls={false}
+            />
+          )}
           {mobilePanel === 'solution' && (
             <SolutionPanel
               listState={listState}
@@ -587,7 +618,11 @@ function WorkspaceView() {
               problemCode={problemCode}
               commentsVisible={commentsVisible}
               onToggleComments={() => setCommentsVisible((current) => !current)}
-              showClose={false}
+              minimized={false}
+              fullscreen={false}
+              onMinimize={() => undefined}
+              onFullscreen={() => undefined}
+              showPanelControls={false}
             />
           )}
           {mobilePanel === 'tests' && (
@@ -600,7 +635,11 @@ function WorkspaceView() {
               testData={testData}
               testState={testState}
               onDownload={() => setDownloadOpen(true)}
-              showClose={false}
+              minimized={false}
+              fullscreen={false}
+              onMinimize={() => undefined}
+              onFullscreen={() => undefined}
+              showPanelControls={false}
             />
           )}
         </div>
@@ -623,60 +662,169 @@ function PanelHeader({
   icon,
   title,
   children,
-  onClose,
-  showClose,
+  minimized,
+  fullscreen,
+  onMinimize,
+  onFullscreen,
+  showPanelControls,
+  hideTitleWhenMinimized = false,
 }: {
   icon: React.ReactNode;
   title: string;
   children?: React.ReactNode;
-  onClose?: () => void;
-  showClose: boolean;
+  minimized: boolean;
+  fullscreen: boolean;
+  onMinimize: () => void;
+  onFullscreen: () => void;
+  showPanelControls: boolean;
+  hideTitleWhenMinimized?: boolean;
 }) {
   return (
-    <div className="flex min-h-11 shrink-0 items-center justify-between gap-3 border-b border-border-default bg-surface-200 px-3">
+    <div
+      className={`group relative flex h-11 shrink-0 items-center border-b border-border-default bg-surface-200 ${
+        minimized && hideTitleWhenMinimized ? 'justify-center px-0' : 'justify-between gap-3 px-3'
+      }`}
+    >
       <div className="flex min-w-0 items-center gap-2 text-xs font-semibold text-foreground">
-        <span className="text-brand">{icon}</span>
-        <span className="truncate">{title}</span>
+        <span className="shrink-0 text-brand">{icon}</span>
+        {(!minimized || !hideTitleWhenMinimized) && <span className="truncate">{title}</span>}
       </div>
-      <div className="flex min-w-0 items-center gap-1.5">
-        {children}
-        {showClose && onClose && (
+      {!minimized && (
+        <div className="flex min-w-0 items-center gap-1.5">
+          {children}
+          {showPanelControls && (
+            <div className="flex items-center opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
+              <button
+                type="button"
+                onClick={onFullscreen}
+                className="rounded p-1.5 text-foreground-lighter hover:bg-surface-300 hover:text-foreground"
+                aria-label={`${fullscreen ? 'Exit fullscreen for' : 'Fullscreen'} ${title} panel`}
+                title={fullscreen ? 'Exit fullscreen' : 'Fullscreen'}
+              >
+                {fullscreen ? (
+                  <ExitFullScreenIcon width="13" height="13" />
+                ) : (
+                  <EnterFullScreenIcon width="13" height="13" />
+                )}
+              </button>
+              <button
+                type="button"
+                onClick={onMinimize}
+                className="rounded p-1.5 text-foreground-lighter hover:bg-surface-300 hover:text-foreground"
+                aria-label={`Minimize ${title} panel`}
+                title="Minimize"
+              >
+                <ChevronDownIcon width="13" height="13" />
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+      {minimized && showPanelControls && (
+        <div
+          className={`opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 ${
+            hideTitleWhenMinimized
+              ? 'absolute inset-0 flex items-center justify-center bg-surface-200'
+              : ''
+          }`}
+        >
           <button
             type="button"
-            onClick={onClose}
+            onClick={onMinimize}
             className="rounded p-1.5 text-foreground-lighter hover:bg-surface-300 hover:text-foreground"
-            aria-label={`Close ${title} panel`}
-            title={`Close ${title}`}
+            aria-label={`Restore ${title} panel`}
+            title="Restore"
           >
-            <Cross2Icon width="13" height="13" />
+            <ChevronUpIcon width="13" height="13" />
           </button>
-        )}
-      </div>
+        </div>
+      )}
     </div>
   );
 }
 
-function EditorialPanel({ onClose, showClose }: { onClose?: () => void; showClose: boolean }) {
+function EditorialPanel({
+  problemInfo,
+  contestYear,
+  problemCode,
+  layoutControls,
+  minimized,
+  fullscreen,
+  onMinimize,
+  onFullscreen,
+  showPanelControls,
+}: {
+  problemInfo: (typeof problems)[number] | undefined;
+  contestYear: string;
+  problemCode: string;
+  layoutControls?: React.ReactNode;
+  minimized: boolean;
+  fullscreen: boolean;
+  onMinimize: () => void;
+  onFullscreen: () => void;
+  showPanelControls: boolean;
+}) {
+  const title = problemInfo?.name || `${contestYear} ${problemCode.toUpperCase()}`;
+
   return (
     <section className="flex size-full min-h-0 flex-col" aria-label="Editorial">
       <PanelHeader
         icon={<ReaderIcon width="15" height="15" />}
-        title="Editorial"
-        onClose={onClose}
-        showClose={showClose}
+        title={title}
+        minimized={minimized}
+        fullscreen={fullscreen}
+        onMinimize={onMinimize}
+        onFullscreen={onFullscreen}
+        showPanelControls={showPanelControls}
+        hideTitleWhenMinimized
       >
-        <Button asChild type="primary" size="tiny">
-          <Link href="/create-post">Ask a question</Link>
-        </Button>
+        {layoutControls}
       </PanelHeader>
-      <article className="min-h-0 flex-1 overflow-y-auto px-5 py-6 sm:px-7">
-        <div className="mb-5 rounded-md border border-brand-300 bg-brand-200 px-3 py-2 text-xs text-brand-600 dark:text-brand">
-          Preview editorial · placeholder content only
-        </div>
-        <div className="mx-auto max-w-3xl [&_h1]:mb-3 [&_h1]:mt-8 [&_h1]:text-xl [&_h1]:font-semibold [&_h1]:tracking-tight [&_h1]:text-foreground [&_h1:first-child]:mt-0 [&_blockquote]:rounded-r-md [&_blockquote]:border-l-2 [&_blockquote]:border-brand-400 [&_blockquote]:bg-surface-200 [&_blockquote]:px-3 [&_blockquote]:py-2">
-          <MarkdownPreview content={MOCK_EDITORIAL} />
-        </div>
-      </article>
+      {!minimized && (
+        <article className="min-h-0 flex-1 overflow-y-auto px-5 py-5 sm:px-7">
+          <div className="mx-auto mb-6 max-w-3xl border-b border-border-default pb-5">
+            <Link
+              href="/solutions"
+              className="mb-3 inline-flex items-center gap-1.5 text-xs text-foreground-lighter transition-colors hover:text-foreground"
+            >
+              <ArrowLeftIcon width="13" height="13" />
+              Back to solutions
+            </Link>
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div className="min-w-0">
+                <h1 className="text-xl font-semibold tracking-tight text-foreground sm:text-2xl">
+                  {title}
+                </h1>
+                <div className="mt-3 flex flex-wrap gap-1.5">
+                  {problemInfo?.difficulty && (
+                    <span
+                      className={`inline-flex items-center rounded-xs px-2.5 py-1 text-[11px] font-medium leading-none ${difficultyClass(
+                        problemInfo.difficulty
+                      )}`}
+                    >
+                      {problemInfo.difficulty}
+                    </span>
+                  )}
+                  {problemInfo?.tags?.map((tag) => (
+                    <span
+                      key={tag}
+                      className="rounded-xs border border-border-default bg-surface-200 px-2 py-0.5 text-[10px] font-medium text-foreground-light"
+                    >
+                      {tag}
+                    </span>
+                  ))}
+                </div>
+              </div>
+              <Button asChild type="default" size="tiny">
+                <Link href="/create-post">Ask a question</Link>
+              </Button>
+            </div>
+          </div>
+          <div className="mx-auto max-w-3xl [&_h1]:mb-3 [&_h1]:mt-8 [&_h1]:text-xl [&_h1]:font-semibold [&_h1]:tracking-tight [&_h1]:text-foreground [&_h1:first-child]:mt-0 [&_blockquote]:rounded-r-md [&_blockquote]:border-l-2 [&_blockquote]:border-brand-400 [&_blockquote]:bg-surface-200 [&_blockquote]:px-3 [&_blockquote]:py-2">
+            <MarkdownPreview content={EDITORIAL_CONTENT} />
+          </div>
+        </article>
+      )}
     </section>
   );
 }
@@ -692,8 +840,11 @@ function SolutionPanel({
   problemCode,
   commentsVisible,
   onToggleComments,
-  onClose,
-  showClose,
+  minimized,
+  fullscreen,
+  onMinimize,
+  onFullscreen,
+  showPanelControls,
 }: {
   listState: ListState;
   solutions: ContestSolutionMeta[];
@@ -705,16 +856,22 @@ function SolutionPanel({
   problemCode: string;
   commentsVisible: boolean;
   onToggleComments: () => void;
-  onClose?: () => void;
-  showClose: boolean;
+  minimized: boolean;
+  fullscreen: boolean;
+  onMinimize: () => void;
+  onFullscreen: () => void;
+  showPanelControls: boolean;
 }) {
   return (
     <section className="flex size-full min-h-0 flex-col" aria-label="Solution">
       <PanelHeader
         icon={<CodeIcon width="15" height="15" />}
         title="Solution"
-        onClose={onClose}
-        showClose={showClose}
+        minimized={minimized}
+        fullscreen={fullscreen}
+        onMinimize={onMinimize}
+        onFullscreen={onFullscreen}
+        showPanelControls={showPanelControls}
       >
         {solutions.length > 0 && activeSolutionIndex !== null && (
           <select
@@ -730,20 +887,15 @@ function SolutionPanel({
             ))}
           </select>
         )}
-        <button
-          type="button"
+        <Button
+          type={commentsVisible ? 'primary' : 'default'}
+          size="tiny"
           onClick={onToggleComments}
           aria-pressed={commentsVisible}
-          className={`inline-flex h-7 items-center gap-1 rounded-md border px-2 text-[11px] transition-colors ${
-            commentsVisible
-              ? 'border-brand-400 bg-brand-200 text-brand-600 dark:text-brand'
-              : 'border-border-strong bg-surface-100 text-foreground-lighter hover:text-foreground'
-          }`}
           title="Toggle inline comments"
         >
-          <ChatBubbleIcon width="12" height="12" />
-          <span className="hidden xl:inline">Comments</span>
-        </button>
+          Comments
+        </Button>
         {solution && (
           <a
             href={contestDownloadUrl(
@@ -760,26 +912,28 @@ function SolutionPanel({
         )}
       </PanelHeader>
 
-      <div className="min-h-0 flex-1">
-        {listState === 'loading' || solutionState === 'loading' ? (
-          <PanelStatus label="Loading solution…" loading />
-        ) : listState === 'invalid' ? (
-          <PanelStatus label="This problem does not exist." />
-        ) : listState === 'error' || solutionState === 'error' ? (
-          <PanelStatus label="Unable to load solutions right now." error />
-        ) : solutions.length === 0 ? (
-          <PanelStatus label="No solution is available yet." />
-        ) : solution ? (
-          <CommentableCode
-            key={`${solution.n}.${solution.ext}`}
-            code={solution.code}
-            language={solution.language}
-            commentsVisible={commentsVisible}
-          />
-        ) : (
-          <PanelStatus label="Choose a solution to view its code." />
-        )}
-      </div>
+      {!minimized && (
+        <div className="min-h-0 flex-1">
+          {listState === 'loading' || solutionState === 'loading' ? (
+            <PanelStatus label="Loading solution…" loading />
+          ) : listState === 'invalid' ? (
+            <PanelStatus label="This problem does not exist." />
+          ) : listState === 'error' || solutionState === 'error' ? (
+            <PanelStatus label="Unable to load solutions right now." error />
+          ) : solutions.length === 0 ? (
+            <PanelStatus label="No solution is available yet." />
+          ) : solution ? (
+            <CommentableCode
+              key={`${solution.n}.${solution.ext}`}
+              code={solution.code}
+              language={solution.language}
+              commentsVisible={commentsVisible}
+            />
+          ) : (
+            <PanelStatus label="Choose a solution to view its code." />
+          )}
+        </div>
+      )}
     </section>
   );
 }
@@ -793,8 +947,11 @@ function TestsPanel({
   testData,
   testState,
   onDownload,
-  onClose,
-  showClose,
+  minimized,
+  fullscreen,
+  onMinimize,
+  onFullscreen,
+  showPanelControls,
 }: {
   listState: ListState;
   tests: ContestTestMeta[];
@@ -804,8 +961,11 @@ function TestsPanel({
   testData: TestCaseData;
   testState: LoadState;
   onDownload: () => void;
-  onClose?: () => void;
-  showClose: boolean;
+  minimized: boolean;
+  fullscreen: boolean;
+  onMinimize: () => void;
+  onFullscreen: () => void;
+  showPanelControls: boolean;
 }) {
   const largeFile =
     activeTest && Math.max(activeTest.inputBytes, activeTest.outputBytes) > LARGE_FILE_BYTES;
@@ -815,8 +975,11 @@ function TestsPanel({
       <PanelHeader
         icon={<FileTextIcon width="15" height="15" />}
         title="Test cases"
-        onClose={onClose}
-        showClose={showClose}
+        minimized={minimized}
+        fullscreen={fullscreen}
+        onMinimize={onMinimize}
+        onFullscreen={onFullscreen}
+        showPanelControls={showPanelControls}
       >
         {tests.length > 0 && (
           <button
@@ -831,7 +994,7 @@ function TestsPanel({
         )}
       </PanelHeader>
 
-      {tests.length > 0 && (
+      {!minimized && tests.length > 0 && (
         <div className="flex shrink-0 gap-1.5 overflow-x-auto border-b border-border-default bg-surface-100 px-3 py-2">
           {tests.map((test, index) => (
             <button
@@ -850,38 +1013,40 @@ function TestsPanel({
         </div>
       )}
 
-      <div className="min-h-0 flex-1 overflow-auto p-3">
-        {listState === 'loading' || testState === 'loading' ? (
-          <PanelStatus label="Loading test case…" loading />
-        ) : listState === 'invalid' ? (
-          <PanelStatus label="This problem does not exist." />
-        ) : listState === 'error' ? (
-          <PanelStatus label="Unable to load test cases right now." error />
-        ) : tests.length === 0 ? (
-          <PanelStatus label="No test cases are available." />
-        ) : testState === 'error' ? (
-          <PanelStatus label="This test case could not be previewed." error />
-        ) : testState === 'success' && activeTest ? (
-          <div className="space-y-3">
-            {largeFile && (
-              <div className="flex items-start gap-2 rounded-md border border-warning-400 bg-warning-200 px-3 py-2 text-xs text-warning-600">
-                <ExclamationTriangleIcon width="13" height="13" className="mt-0.5 shrink-0" />
-                Preview is truncated because this is a large file. Download it for the full data.
+      {!minimized && (
+        <div className="min-h-0 flex-1 overflow-auto p-3">
+          {listState === 'loading' || testState === 'loading' ? (
+            <PanelStatus label="Loading test case…" loading />
+          ) : listState === 'invalid' ? (
+            <PanelStatus label="This problem does not exist." />
+          ) : listState === 'error' ? (
+            <PanelStatus label="Unable to load test cases right now." error />
+          ) : tests.length === 0 ? (
+            <PanelStatus label="No test cases are available." />
+          ) : testState === 'error' ? (
+            <PanelStatus label="This test case could not be loaded." error />
+          ) : testState === 'success' && activeTest ? (
+            <div className="space-y-3">
+              {largeFile && (
+                <div className="flex items-start gap-2 rounded-md border border-warning-400 bg-warning-200 px-3 py-2 text-xs text-warning-600">
+                  <ExclamationTriangleIcon width="13" height="13" className="mt-0.5 shrink-0" />
+                  This file is too large to display in full. Download it for the complete data.
+                </div>
+              )}
+              <div className="grid grid-cols-1 gap-3 xl:grid-cols-2">
+                <TestValue label="Input" bytes={activeTest.inputBytes} value={testData.input} />
+                <TestValue
+                  label="Expected output"
+                  bytes={activeTest.outputBytes}
+                  value={testData.output}
+                />
               </div>
-            )}
-            <div className="grid grid-cols-1 gap-3 xl:grid-cols-2">
-              <TestValue label="Input" bytes={activeTest.inputBytes} value={testData.input} />
-              <TestValue
-                label="Expected output"
-                bytes={activeTest.outputBytes}
-                value={testData.output}
-              />
             </div>
-          </div>
-        ) : (
-          <PanelStatus label="Select a test case to view its input and output." />
-        )}
-      </div>
+          ) : (
+            <PanelStatus label="Select a test case to view its input and output." />
+          )}
+        </div>
+      )}
     </section>
   );
 }

--- a/website/app/contest/[contestYear]/[problemCode]/new-solution-preview/SolutionPreviewClient.tsx
+++ b/website/app/contest/[contestYear]/[problemCode]/new-solution-preview/SolutionPreviewClient.tsx
@@ -6,7 +6,6 @@ import Link from 'next/link';
 import { useParams } from 'next/navigation';
 import {
   ArrowLeftIcon,
-  CheckIcon,
   ChevronDownIcon,
   ChevronLeftIcon,
   ChevronRightIcon,
@@ -1046,18 +1045,13 @@ function SolutionSelect({
                   aria-selected={selectedOption}
                   onMouseEnter={() => setFocusedIndex(index)}
                   onClick={() => choose(index)}
-                  className={`flex w-full items-center justify-between gap-3 rounded px-2 py-1.5 text-left text-[11px] transition-colors ${
+                  className={`flex w-full items-center rounded px-2 py-1.5 text-left text-[11px] transition-colors ${
                     focusedOption ? 'bg-surface-300 text-foreground' : 'text-foreground-light'
                   }`}
                 >
                   <span className="whitespace-nowrap">
                     {index + 1} · {languageLabel(languageFromExtension(entry.ext))}
                   </span>
-                  <CheckIcon
-                    width="12"
-                    height="12"
-                    className={selectedOption ? 'text-brand' : 'invisible'}
-                  />
                 </button>
               );
             })}

--- a/website/app/contest/[contestYear]/[problemCode]/new-solution-preview/SolutionPreviewClient.tsx
+++ b/website/app/contest/[contestYear]/[problemCode]/new-solution-preview/SolutionPreviewClient.tsx
@@ -1134,7 +1134,7 @@ function SolutionPanel({
           type="button"
           onClick={onStartComment}
           disabled={!solution}
-          className="rounded border border-border-strong bg-surface-100 p-1.5 text-brand transition-colors hover:border-brand-400 hover:bg-brand-200 disabled:cursor-not-allowed disabled:opacity-40"
+          className="rounded border border-border-strong bg-surface-100 p-1.5 text-foreground-lighter transition-colors hover:bg-surface-300 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-40"
           aria-label="Add comment"
           title="Add comment"
         >

--- a/website/app/contest/[contestYear]/[problemCode]/new-solution-preview/SolutionPreviewClient.tsx
+++ b/website/app/contest/[contestYear]/[problemCode]/new-solution-preview/SolutionPreviewClient.tsx
@@ -524,7 +524,7 @@ function WorkspaceView({
   );
 
   return (
-    <div className="mb-3 flex min-h-[70dvh] flex-col bg-background text-foreground lg:h-[calc(100dvh-var(--nav-h)-0.75rem)] lg:min-h-0">
+    <div className="mb-3 flex min-h-[70dvh] flex-col bg-background text-foreground lg:mb-0 lg:h-[calc(100dvh-var(--nav-h))] lg:min-h-0">
       <div ref={desktopRef} className="hidden min-h-0 flex-1 p-3 lg:flex">
         {fullscreen ? (
           <div className="min-h-0 min-w-0 flex-1 overflow-hidden rounded-lg border border-border-default bg-surface-100">

--- a/website/app/contest/[contestYear]/[problemCode]/new-solution-preview/SolutionPreviewClient.tsx
+++ b/website/app/contest/[contestYear]/[problemCode]/new-solution-preview/SolutionPreviewClient.tsx
@@ -415,7 +415,10 @@ function WorkspaceView({
   const toggleMinimized = (panel: PanelName) => {
     setFullscreen(null);
     setMinimized((current) => {
-      const next = { ...current, [panel]: !current[panel] };
+      const next = {
+        ...current,
+        [panel]: fullscreen === panel ? true : !current[panel],
+      };
 
       if (next.solution && next.tests) {
         const otherPanel = panel === 'solution' ? 'tests' : 'solution';
@@ -427,7 +430,6 @@ function WorkspaceView({
   };
 
   const toggleFullscreen = (panel: PanelName) => {
-    setMinimized((current) => ({ ...current, [panel]: false }));
     setFullscreen((current) => (current === panel ? null : panel));
   };
 
@@ -477,7 +479,7 @@ function WorkspaceView({
       layoutControls={
         <LayoutControls view={view} onViewChange={onViewChange} onReset={resetLayout} />
       }
-      minimized={minimized.editorial}
+      minimized={fullscreen === 'editorial' ? false : minimized.editorial}
       fullscreen={fullscreen === 'editorial'}
       onMinimize={() => toggleMinimized('editorial')}
       onFullscreen={() => toggleFullscreen('editorial')}
@@ -498,7 +500,7 @@ function WorkspaceView({
       onToggleComments={() => setCommentsVisible((current) => !current)}
       commentSize={commentSize}
       onCommentSizeChange={setCommentSize}
-      minimized={minimized.solution}
+      minimized={fullscreen === 'solution' ? false : minimized.solution}
       fullscreen={fullscreen === 'solution'}
       onMinimize={() => toggleMinimized('solution')}
       onFullscreen={() => toggleFullscreen('solution')}
@@ -515,7 +517,7 @@ function WorkspaceView({
       testData={testData}
       testState={testState}
       onDownload={() => setDownloadOpen(true)}
-      minimized={minimized.tests}
+      minimized={fullscreen === 'tests' ? false : minimized.tests}
       fullscreen={fullscreen === 'tests'}
       onMinimize={() => toggleMinimized('tests')}
       onFullscreen={() => toggleFullscreen('tests')}

--- a/website/app/contest/[contestYear]/[problemCode]/new-solution-preview/SolutionPreviewClient.tsx
+++ b/website/app/contest/[contestYear]/[problemCode]/new-solution-preview/SolutionPreviewClient.tsx
@@ -16,6 +16,7 @@ import {
   ExitFullScreenIcon,
   FileTextIcon,
   InfoCircledIcon,
+  PlusIcon,
   ReaderIcon,
   ResetIcon,
 } from '@radix-ui/react-icons';
@@ -234,6 +235,7 @@ function WorkspaceView({
   const [testState, setTestState] = useState<LoadState>('idle');
   const [downloadOpen, setDownloadOpen] = useState(false);
   const [commentsVisible, setCommentsVisible] = useState(true);
+  const [commentComposerRequest, setCommentComposerRequest] = useState(0);
   const [minimized, setMinimized] = useState<MinimizedState>(DEFAULT_MINIMIZED);
   const [fullscreen, setFullscreen] = useState<PanelName | null>(null);
   const [leftSize, setLeftSize] = useState(DEFAULT_LEFT_SIZE);
@@ -471,6 +473,11 @@ function WorkspaceView({
     window.addEventListener('pointerup', stop);
   };
 
+  const startComment = () => {
+    setCommentsVisible(true);
+    setCommentComposerRequest((current) => current + 1);
+  };
+
   const editorialPanel = (
     <EditorialPanel
       problemInfo={problemInfo}
@@ -498,6 +505,8 @@ function WorkspaceView({
       problemCode={problemCode}
       commentsVisible={commentsVisible}
       onToggleComments={() => setCommentsVisible((current) => !current)}
+      onStartComment={startComment}
+      composerRequest={commentComposerRequest}
       commentSize={commentSize}
       onCommentSizeChange={setCommentSize}
       minimized={fullscreen === 'solution' ? false : minimized.solution}
@@ -652,6 +661,8 @@ function WorkspaceView({
               problemCode={problemCode}
               commentsVisible={commentsVisible}
               onToggleComments={() => setCommentsVisible((current) => !current)}
+              onStartComment={startComment}
+              composerRequest={commentComposerRequest}
               commentSize={commentSize}
               onCommentSizeChange={setCommentSize}
               minimized={false}
@@ -917,6 +928,8 @@ function SolutionPanel({
   problemCode,
   commentsVisible,
   onToggleComments,
+  onStartComment,
+  composerRequest,
   commentSize,
   onCommentSizeChange,
   minimized,
@@ -935,6 +948,8 @@ function SolutionPanel({
   problemCode: string;
   commentsVisible: boolean;
   onToggleComments: () => void;
+  onStartComment: () => void;
+  composerRequest: number;
   commentSize: number;
   onCommentSizeChange: (size: number) => void;
   minimized: boolean;
@@ -977,6 +992,16 @@ function SolutionPanel({
         >
           Comments
         </Button>
+        <button
+          type="button"
+          onClick={onStartComment}
+          disabled={!solution}
+          className="rounded border border-border-strong bg-surface-100 p-1.5 text-foreground-light transition-colors hover:bg-surface-300 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-40"
+          aria-label="Add comment"
+          title="Add comment"
+        >
+          <PlusIcon width="13" height="13" />
+        </button>
         {solution && (
           <a
             href={contestDownloadUrl(
@@ -1009,6 +1034,7 @@ function SolutionPanel({
               code={solution.code}
               language={solution.language}
               commentsVisible={commentsVisible}
+              composerRequest={composerRequest}
               onCloseComments={onToggleComments}
               railWidth={commentSize}
               onRailWidthChange={onCommentSizeChange}

--- a/website/app/contest/[contestYear]/[problemCode]/new-solution-preview/SolutionPreviewClient.tsx
+++ b/website/app/contest/[contestYear]/[problemCode]/new-solution-preview/SolutionPreviewClient.tsx
@@ -1,10 +1,12 @@
 'use client';
 
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
 import {
   ArrowLeftIcon,
+  CheckIcon,
   ChevronDownIcon,
   ChevronLeftIcon,
   ChevronRightIcon,
@@ -917,6 +919,155 @@ function EditorialPanel({
   );
 }
 
+function SolutionSelect({
+  solutions,
+  value,
+  onChange,
+}: {
+  solutions: ContestSolutionMeta[];
+  value: number;
+  onChange: (index: number) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [focusedIndex, setFocusedIndex] = useState(value);
+  const [position, setPosition] = useState<{ top: number; left: number; minWidth: number } | null>(
+    null
+  );
+  const selectId = useId().replace(/[^a-zA-Z0-9_-]/g, '');
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  const updatePosition = useCallback(() => {
+    const rect = triggerRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    setPosition({ top: rect.bottom + 4, left: rect.left, minWidth: rect.width });
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    updatePosition();
+
+    const closeOnOutsideClick = (event: PointerEvent) => {
+      const target = event.target as Node;
+      if (triggerRef.current?.contains(target) || menuRef.current?.contains(target)) return;
+      setOpen(false);
+    };
+    const reposition = () => updatePosition();
+    document.addEventListener('pointerdown', closeOnOutsideClick);
+    window.addEventListener('resize', reposition);
+    window.addEventListener('scroll', reposition, true);
+    return () => {
+      document.removeEventListener('pointerdown', closeOnOutsideClick);
+      window.removeEventListener('resize', reposition);
+      window.removeEventListener('scroll', reposition, true);
+    };
+  }, [open, updatePosition]);
+
+  const choose = (index: number) => {
+    onChange(index);
+    setFocusedIndex(index);
+    setOpen(false);
+    triggerRef.current?.focus();
+  };
+
+  const moveFocus = (direction: 1 | -1) => {
+    setFocusedIndex((current) => (current + direction + solutions.length) % solutions.length);
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+      event.preventDefault();
+      if (!open) {
+        setFocusedIndex(value);
+        setOpen(true);
+      } else {
+        moveFocus(event.key === 'ArrowDown' ? 1 : -1);
+      }
+      return;
+    }
+    if (event.key === 'Escape' && open) {
+      event.preventDefault();
+      setOpen(false);
+      return;
+    }
+    if (event.key === 'Enter' && open) {
+      event.preventDefault();
+      choose(focusedIndex);
+    }
+  };
+
+  const selected = solutions[value];
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        onClick={() => {
+          setFocusedIndex(value);
+          setOpen((current) => !current);
+        }}
+        onKeyDown={handleKeyDown}
+        className="inline-flex h-7 max-w-36 items-center justify-between gap-2 rounded-md border border-border-strong bg-surface-100 px-2 text-[11px] text-foreground transition-colors hover:bg-surface-300 focus:border-brand-highlight focus:outline-none"
+        aria-label="Choose solution"
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-controls={`solution-select-${selectId}`}
+      >
+        <span className="truncate">
+          {value + 1} · {languageLabel(languageFromExtension(selected?.ext ?? ''))}
+        </span>
+        <ChevronDownIcon
+          width="12"
+          height="12"
+          className={`shrink-0 transition-transform ${open ? 'rotate-180' : ''}`}
+        />
+      </button>
+      {open &&
+        position &&
+        createPortal(
+          <div
+            ref={menuRef}
+            id={`solution-select-${selectId}`}
+            role="listbox"
+            aria-label="Solutions"
+            className="fixed z-[100] max-h-56 min-w-28 overflow-y-auto rounded-md border border-border-strong bg-surface-100 p-1 shadow-xl"
+            style={position}
+          >
+            {solutions.map((entry, index) => {
+              const selectedOption = index === value;
+              const focusedOption = index === focusedIndex;
+              return (
+                <button
+                  key={`${entry.n}.${entry.ext}`}
+                  id={`solution-option-${selectId}-${index}`}
+                  type="button"
+                  role="option"
+                  aria-selected={selectedOption}
+                  onMouseEnter={() => setFocusedIndex(index)}
+                  onClick={() => choose(index)}
+                  className={`flex w-full items-center justify-between gap-3 rounded px-2 py-1.5 text-left text-[11px] transition-colors ${
+                    focusedOption ? 'bg-surface-300 text-foreground' : 'text-foreground-light'
+                  }`}
+                >
+                  <span className="whitespace-nowrap">
+                    {index + 1} · {languageLabel(languageFromExtension(entry.ext))}
+                  </span>
+                  <CheckIcon
+                    width="12"
+                    height="12"
+                    className={selectedOption ? 'text-brand' : 'invisible'}
+                  />
+                </button>
+              );
+            })}
+          </div>,
+          document.body
+        )}
+    </>
+  );
+}
+
 function SolutionPanel({
   listState,
   solutions,
@@ -970,18 +1121,11 @@ function SolutionPanel({
         showPanelControls={showPanelControls}
       >
         {solutions.length > 0 && activeSolutionIndex !== null && (
-          <select
+          <SolutionSelect
+            solutions={solutions}
             value={activeSolutionIndex}
-            onChange={(event) => onSolutionChange(Number(event.target.value))}
-            className="h-7 max-w-36 rounded-md border border-border-strong bg-surface-100 px-2 text-[11px] text-foreground focus:border-brand-highlight focus:outline-none"
-            aria-label="Choose solution"
-          >
-            {solutions.map((entry, index) => (
-              <option key={`${entry.n}.${entry.ext}`} value={index}>
-                {index + 1} · {languageLabel(languageFromExtension(entry.ext))}
-              </option>
-            ))}
-          </select>
+            onChange={onSolutionChange}
+          />
         )}
         <Button
           type={commentsVisible ? 'primary' : 'default'}
@@ -996,7 +1140,7 @@ function SolutionPanel({
           type="button"
           onClick={onStartComment}
           disabled={!solution}
-          className="rounded border border-border-strong bg-surface-100 p-1.5 text-foreground-light transition-colors hover:bg-surface-300 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-40"
+          className="rounded border border-border-strong bg-surface-100 p-1.5 text-brand transition-colors hover:border-brand-400 hover:bg-brand-200 disabled:cursor-not-allowed disabled:opacity-40"
           aria-label="Add comment"
           title="Add comment"
         >

--- a/website/app/contest/[contestYear]/[problemCode]/new-solution-preview/page.tsx
+++ b/website/app/contest/[contestYear]/[problemCode]/new-solution-preview/page.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from 'next';
+import SolutionPreviewClient from './SolutionPreviewClient';
+
+export const metadata: Metadata = {
+  title: 'Solution workspace preview | CCCSolutions',
+  robots: { index: false, follow: false },
+};
+
+export default function NewSolutionPreviewPage() {
+  return <SolutionPreviewClient />;
+}

--- a/website/app/contest/[contestYear]/[problemCode]/new-solution-preview/page.tsx
+++ b/website/app/contest/[contestYear]/[problemCode]/new-solution-preview/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next';
 import SolutionPreviewClient from './SolutionPreviewClient';
 
 export const metadata: Metadata = {
-  title: 'Solution workspace preview | CCCSolutions',
+  title: 'Solution workspace | CCCSolutions',
   robots: { index: false, follow: false },
 };
 

--- a/website/lib/contest-api.ts
+++ b/website/lib/contest-api.ts
@@ -1,0 +1,36 @@
+export const CONTEST_API_BASE = process.env.NEXT_PUBLIC_API_URL ?? 'https://api.cccsolutions.ca';
+
+export interface ContestTestMeta {
+  n: number;
+  sample: boolean;
+  inputBytes: number;
+  outputBytes: number;
+}
+
+export interface ContestSolutionMeta {
+  n: number;
+  ext: string;
+  bytes: number;
+}
+
+export interface ContestListResponse {
+  tests: ContestTestMeta[];
+  solutions: ContestSolutionMeta[];
+}
+
+export function fetchContestList(year: string, code: string, signal?: AbortSignal) {
+  return fetch(`${CONTEST_API_BASE}/contests/${year}/${code}/list`, { signal });
+}
+
+export function fetchContestPreview(
+  year: string,
+  code: string,
+  file: string,
+  signal?: AbortSignal
+) {
+  return fetch(`${CONTEST_API_BASE}/contests/${year}/${code}/preview?file=${file}`, { signal });
+}
+
+export function contestDownloadUrl(year: string, code: string, file: string) {
+  return `${CONTEST_API_BASE}/contests/${year}/${code}/download?file=${file}`;
+}


### PR DESCRIPTION
## Description

Adds a frontend-only preview of a more usable, LeetCode-style solution workspace while preserving the current page for direct comparison. The preview reuses the existing contest API and download flow, so no backend, schema, or persistence changes are required.

Preview route: `/contest/2026/j1/new-solution-preview`

## Changes

- Add an in-page Classic/New selector beside the problem title; switching views does not navigate away.
- Add a compact three-panel desktop workspace with draggable dividers, always-visible minimize/fullscreen controls, and a layout reset action in the New view.
- Collapse the editorial into a narrow vertical rail and keep at least one of Solution or Test cases open.
- Persist panel sizes, comment width, and minimized state locally so the workspace survives reloads.
- Add a mobile tab layout for the same three views.
- Load real solutions and test cases through the existing contest API, including existing downloads, loading states, missing-data states, and large-test warnings.
- Add a structured mock editorial with an Ask a question link to the forum post flow.
- Add a resizable, closable Google Docs-style comment rail with amber CSS Highlight API ranges, a movable caret target, a header add action, and a plain-text composer above newest-first threads.
- Replace the browser solution select with a compact, keyboard-operable themed dropdown.
- Share the existing contest API helpers between the classic and preview pages without changing their endpoints or backend behavior.

## Testing

- `bun run typecheck`
- `bun run lint` (passes with the pre-existing custom-font warning in `app/layout.tsx`)
- `bun run format:check`
- `bun run build`
- Production server smoke test: preview route returned HTTP 200.
- Live API smoke test: 2026 J1 returned real solutions and test cases; a real solution preview loaded successfully.
- Confirmed the API returns the deployment preview origin in `Access-Control-Allow-Origin` for a Netlify preview hostname.

## Checklist

- [x] I read CONTRIBUTING.md and gave my own code a once-over (it runs and does what the PR says)
- [x] `tsc`, lint, and tests pass locally (CI checks these too)
- [x] New backend feature code (`backend/src/`) has vitest tests (no backend code changed)
- [x] Code is formatted and matches the surrounding style (CI checks this)
- [x] Docs/comments updated if behavior or APIs changed (no API behavior changed)
