### PR TITLE
docs: expand CONTRIBUTING (local DB, tests, PR flow) + pin prettier

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,25 +4,71 @@ Thanks for helping out! This is a community project, so don't stress about getti
 
 ## Ways to contribute
 
-- **Help build a new planned feature** — please check the issue board, there are also many issues tagged `good first issue`!
-- **Fix the site** — bugs, UI, performance.
-- **Report a bug or suggest something** — open a new issue.
+- **Help build a new planned feature.** Please check the issue board. Many issues are tagged `good first issue`.
+- **Fix the site.** Bugs, UI, performance.
+- **Report a bug or suggest something.** Open a new issue.
 
 ## Dev setup
 
-You'll need [bun](https://bun.sh).
+You'll need [bun](https://bun.sh). The repo has two apps you run separately.
 
-- **Frontend** (`website/`): `bun install`, then `bun run dev` (Next.js).
-- **Backend** (`backend/`): `bun install`, then `bun run dev` (Cloudflare Workers via Wrangler). See `backend/CLAUDE.md` for the rules.
+- **Frontend** (`website/`): `bun install`, then `bun run dev` (Next.js on `localhost:3000`).
+- **Backend** (`backend/`): `bun install`, then `bun run dev` (Cloudflare Workers via Wrangler on `localhost:8787`). See `backend/CLAUDE.md` for the rules.
 
-## Style
+Both apps read local secrets from gitignored env files. Copy the examples and fill them in:
 
-- Match the style of the code around you. Run `bun run lint` and the tests before pushing.
-- Adding or changing backend feature code (`backend/src/`)? Add matching vitest tests in `backend/test/`.
+- Frontend: `cp website/.env.local.example website/.env.local`
+- Backend: `cp backend/.dev.vars.example backend/.dev.vars`
+
+The example files explain every value. For the frontend, point `NEXT_PUBLIC_API_URL` at `http://localhost:8787` so it talks to your local backend.
+
+## Running the database locally
+
+Forum, auth, and vote features need Postgres. Local dev uses the Supabase CLI stack, which serves Postgres on `127.0.0.1:54322`. The env examples already point there, so a fresh copy works with no editing.
+
+1. Install [Docker Desktop](https://docs.docker.com/desktop) and the [Supabase CLI](https://supabase.com/docs/guides/local-development). Docker must be running.
+2. Generate a local auth signing key once: `supabase gen signing-key --algorithm ES256`. Save the output as a JSON array in `backend/supabase/signing_keys.json`.
+3. Copy `backend/.env.example` to `backend/.env` for the CLI's own values.
+4. From `backend/`: `supabase start`, then `bun run db:migrate` to apply the schema.
+
+### Migrations
+
+- Change a table? Edit the Drizzle schema in `backend/src/db/schema.ts`, then run `bun run db:generate` to produce a migration in `backend/drizzle/`.
+- Need raw SQL (a grant, a trigger, a backfill)? Run `bunx drizzle-kit generate --custom --name=<what_it_does>` and write the SQL by hand.
+- Apply migrations locally with `bun run db:migrate`.
+- Never run `db:migrate` against production by hand. CI migrates prod on merge to `main`. Keep `DIRECT_DATABASE_URL` pointed at your local stack only.
+
+## Tests
+
+The backend uses vitest. There are two kinds.
+
+- **Unit tests** live in `backend/test/` and run with no database. Run them with `bun run test`. This is what CI runs, and it enforces coverage.
+- **Integration tests** live in `backend/test/integration/` and hit your local Supabase stack. Run them with `bun run test:integration`. CI does not run these (there is no DB there), so they will not fail a PR, but do run them locally when you touch auth, forum, or DB code.
+
+To run the integration suite: `supabase start && bun run db:migrate && bun run test:integration`.
+
+### Writing tests
+
+- Add or change backend feature code in `backend/src/`? Add matching tests in `backend/test/`.
+- Put a test that needs no DB (input validation, a 401 with no auth header) in a unit test. Put anything that reads or writes real rows in an integration test.
+- Integration tests share a harness in `backend/test/integration/env.ts`. Use `signUp(prefix)` to make a real user and get a JWT, `authHeader(token)` to attach it, and `appRequest(path, init)` to call the app.
+- Guard the whole suite with `describe.skipIf(!dbUp)` so it skips cleanly when Supabase is not running instead of failing.
+- Use `appRequest`, not `app.request`, for any route that does background work. Writes call `purgeForum` and `notify` through `waitUntil`. In Node there is no Workers `ExecutionContext`, so `appRequest` supplies a minimal one and waits for those background tasks before returning. Call `app.request` directly and that work never runs.
+
+Look at `backend/test/integration/` for working examples.
+
+## Before you push
+
+Run these in whichever app you changed:
+
+- `bun run typecheck`
+- `bun run lint`
+- `bun run format` (autoformats with Prettier; CI checks formatting and will fail an unformatted diff)
+- `bun run test`
 
 ## Opening a PR
 
 1. Branch off `main` (or the relevant feature branch).
-2. Open a PR and fill out the template — lead with *why*, and link the issue (`Resolves #123`).
-3. CI runs typecheck, lint, and tests — make sure it's green.
+2. Open a PR and fill out the template. Lead with *why*, and link the issue (`Resolves #123`).
+3. CI runs typecheck, lint, format, and tests. Make sure it's green.
 4. Give your own diff a read first. That's it!

--- a/backend/package.json
+++ b/backend/package.json
@@ -37,7 +37,7 @@
     "drizzle-kit": "^0.31.10",
     "eslint": "^10.7.0",
     "globals": "^17.7.0",
-    "prettier": "^3.9.5",
+    "prettier": "3.9.5",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.64.0",
     "vitest": "^4.1.10",

--- a/website/bun.lock
+++ b/website/bun.lock
@@ -39,7 +39,7 @@
         "eslint": "^8.57.0",
         "eslint-config-next": "^15.5.12",
         "postcss": "^8.5.16",
-        "prettier": "^3.9.4",
+        "prettier": "3.9.5",
         "tailwindcss": "^4.3.2",
         "typescript": "^5.9.3",
         "wrangler": "^4.110.0",
@@ -1737,7 +1737,7 @@
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
-    "prettier": ["prettier@3.9.4", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg=="],
+    "prettier": ["prettier@3.9.5", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg=="],
 
     "pretty-bytes": ["pretty-bytes@5.6.0", "", {}, "sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg=="],
 

--- a/website/package.json
+++ b/website/package.json
@@ -51,7 +51,7 @@
     "eslint": "^8.57.0",
     "eslint-config-next": "^15.5.12",
     "postcss": "^8.5.16",
-    "prettier": "^3.9.4",
+    "prettier": "3.9.5",
     "tailwindcss": "^4.3.2",
     "typescript": "^5.9.3",
     "wrangler": "^4.110.0"


### PR DESCRIPTION
## Description

CONTRIBUTING.md only covered bun install and a one-line note about running lint and tests. A new contributor had no way to know how to bring up the local database, which tests exist, or how to write one. This fills that in, in the same friendly voice as the existing doc.

While here, it also pins Prettier to an exact version so a contributor's local `bun run format` produces the same output CI checks. The caret ranges (`^3.9.5` backend, `^3.9.4` website) let the two apps drift, which is how earlier PRs failed the CI format check.

## Changes

- **CONTRIBUTING.md**: local Supabase setup (env files, ES256 signing key, `supabase start`, `db:migrate`); the migration workflow (schema edit + `db:generate`, custom SQL migrations, prod migrated by CI only); unit vs integration tests and how to run each; how to write tests (the `signUp` / `authHeader` / `appRequest` harness, `skipIf(!dbUp)`, and why `appRequest` is required so `waitUntil` background work like `purgeForum` / `notify` runs under Node); a before-push checklist.
- **Prettier pin**: `backend/package.json` and `website/package.json` both pin exactly `3.9.5` (drop the caret); `website/bun.lock` synced. `bun run format` in each app now runs the same pinned Prettier CI uses.
- Removed em dashes from the doc to match the house style.

## Testing

- Docs-only plus a version pin. `cd website && bun install` resolves prettier@3.9.5 with the committed lockfile.
- Followed the guide's own steps locally to confirm they are accurate (env copy, `supabase start`, `db:migrate`, `test:integration`).

## Linked issues

Refs #

## Checklist

- [x] I read CONTRIBUTING.md and gave my own code a once-over (it runs and does what the PR says)
- [x] `tsc`, lint, and tests pass locally (CI checks these too)
- [ ] New backend feature code (`backend/src/`) has vitest tests
- [x] Code is formatted and matches the surrounding style (CI checks this)
- [x] Docs/comments updated if behavior or APIs changed

https://claude.ai/code/session_01TshP4HMuq9JDAJF924zHay