### PR TITLE
feat(forum): Admin badge next to admin authors

### DIFF
--- a/website/app/forum/AdminBadge.tsx
+++ b/website/app/forum/AdminBadge.tsx
@@ -1,0 +1,12 @@
+import { StarFilledIcon } from '@radix-ui/react-icons';
+
+// Shown next to an author's name when their profile role is 'admin'. The backend
+// returns author.role on posts and comments; render this only for admins.
+export function AdminBadge() {
+  return (
+    <span className="ml-1 inline-flex items-center gap-0.5 rounded-full bg-brand-200 px-1.5 py-0.5 align-middle text-[10px] font-semibold uppercase tracking-wide text-brand-600">
+      <StarFilledIcon width="9" height="9" />
+      Admin
+    </span>
+  );
+}

--- a/website/app/forum/[id]/PostPageClient.tsx
+++ b/website/app/forum/[id]/PostPageClient.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react';
 import Link from 'next/link';
 import { ArrowLeftIcon, ArrowUpIcon, ArrowDownIcon } from '@radix-ui/react-icons';
+import { AdminBadge } from '../AdminBadge';
 import { toast } from 'sonner';
 import { Button } from '../../../components/ui/button';
 import { Card, CardContent } from '../../../components/ui/card';
@@ -21,7 +22,7 @@ type PostDetail = {
   content: string;
   score: number;
   createdAt: string;
-  author: { username: string | null };
+  author: { username: string | null; role: string | null };
 };
 
 type CommentRow = {
@@ -29,7 +30,7 @@ type CommentRow = {
   content: string;
   score: number;
   createdAt: string;
-  author: { username: string | null };
+  author: { username: string | null; role: string | null };
 };
 
 type Props = {
@@ -260,8 +261,9 @@ export default function PostPageClient({ id }: Props) {
                 By{' '}
                 <span className="font-semibold text-foreground-light">
                   {post.author?.username ?? 'Unknown'}
-                </span>{' '}
-                on {new Date(post.createdAt).toISOString().split('T')[0]}
+                </span>
+                {post.author?.role === 'admin' && <AdminBadge />} on{' '}
+                {new Date(post.createdAt).toISOString().split('T')[0]}
               </span>
 
               <div className="flex items-center gap-2">
@@ -314,8 +316,9 @@ export default function PostPageClient({ id }: Props) {
                         By{' '}
                         <span className="font-medium text-foreground-light">
                           {comment.author?.username ?? 'Unknown'}
-                        </span>{' '}
-                        on {new Date(comment.createdAt).toISOString().split('T')[0]}
+                        </span>
+                        {comment.author?.role === 'admin' && <AdminBadge />} on{' '}
+                        {new Date(comment.createdAt).toISOString().split('T')[0]}
                       </p>
                       <div className="flex items-center gap-1.5">
                         <button

--- a/website/app/forum/page.tsx
+++ b/website/app/forum/page.tsx
@@ -4,6 +4,7 @@ import React, { useState, useEffect, useCallback } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { ArrowUpIcon, ArrowDownIcon } from '@radix-ui/react-icons';
+import { AdminBadge } from './AdminBadge';
 import { toast } from 'sonner';
 import { Button } from '../../components/ui/button';
 import { Card } from '../../components/ui/card';
@@ -23,7 +24,7 @@ type PostRow = {
   content: string;
   score: number;
   createdAt: string;
-  author: { username: string | null };
+  author: { username: string | null; role: string | null };
 };
 
 // Tracks the current user's vote on each post so the arrows reflect their state.
@@ -327,7 +328,8 @@ export default function ForumPage() {
                         className="text-foreground-light max-h-24 overflow-hidden"
                       />
                       <div className="mt-2 text-xs text-foreground-lighter">
-                        By {post.author?.username ?? 'Unknown'} ·{' '}
+                        By {post.author?.username ?? 'Unknown'}
+                        {post.author?.role === 'admin' && <AdminBadge />} ·{' '}
                         {new Date(post.createdAt).toLocaleDateString()}
                       </div>
                     </div>


### PR DESCRIPTION
## Description

Admins are indistinguishable from anyone else in the forum, so an official post or reply reads like any other. The backend already returns `author.role` on posts and comments, so the data is there; the UI just was not showing it. This adds a small "Admin" badge next to an author's name when their role is `admin`.

Frontend only. There is no moderator role yet, so this checks for `admin` exactly.

## Changes

- New `website/app/forum/AdminBadge.tsx`: a small brand-colored pill (`bg-brand-200` / `text-brand-600`, star icon). The token pair reads well in both light and dark themes.
- Render it next to the author on all three surfaces: the post list (`page.tsx`), the post detail, and each comment (`[id]/PostPageClient.tsx`).
- Add `role` to the `author` shape in the `PostRow`, `PostDetail`, and `CommentRow` types.

## Testing

- `bun run typecheck`, `bun run lint`, and `bun run format` pass. Lint shows only a pre-existing unrelated font warning in `app/layout.tsx`.
- Manually: an admin-authored post and comment show the badge; non-admins do not.

## Linked issues

Refs #

## Checklist

- [x] I read CONTRIBUTING.md and gave my own code a once-over (it runs and does what the PR says)
- [x] `tsc`, lint, and tests pass locally (CI checks these too)
- [ ] New backend feature code (`backend/src/`) has vitest tests
- [x] Code is formatted and matches the surrounding style (CI checks this)
- [ ] Docs/comments updated if behavior or APIs changed
