### PR TITLE
feat(forum): edit/delete UI for posts and comments (frontend)

### DIFF
--- a/website/app/forum/[id]/PostPageClient.tsx
+++ b/website/app/forum/[id]/PostPageClient.tsx
@@ -2,7 +2,14 @@
 
 import React, { useState, useEffect, useCallback, useRef } from 'react';
 import Link from 'next/link';
-import { ArrowLeftIcon, ArrowUpIcon, ArrowDownIcon } from '@radix-ui/react-icons';
+import { useRouter } from 'next/navigation';
+import {
+  ArrowLeftIcon,
+  ArrowUpIcon,
+  ArrowDownIcon,
+  Pencil1Icon,
+  TrashIcon,
+} from '@radix-ui/react-icons';
 import { toast } from 'sonner';
 import { Button } from '../../../components/ui/button';
 import { Card, CardContent } from '../../../components/ui/card';
@@ -49,8 +56,23 @@ export default function PostPageClient({ id }: Props) {
   // submitting === false and each fire a create(). A ref writes synchronously.
   const submittingRef = useRef(false);
 
-  const { state } = useAuth();
+  // Inline edit state. A post/comment shows an edit form in place of its body while its
+  // id (or the post flag) is active.
+  const [editingPost, setEditingPost] = useState(false);
+  const [editTitle, setEditTitle] = useState('');
+  const [editContent, setEditContent] = useState('');
+  const [savingPost, setSavingPost] = useState(false);
+  const [editingCommentId, setEditingCommentId] = useState<string | null>(null);
+  const [editCommentContent, setEditCommentContent] = useState('');
+  const [savingComment, setSavingComment] = useState(false);
+
+  const { state, profile } = useAuth();
   const isLoggedIn = state === 'in';
+  const router = useRouter();
+
+  // Owner check for showing edit/delete controls. This is UI gating only; the backend
+  // enforces authorship on every PATCH/DELETE.
+  const ownsPost = isLoggedIn && !!post && post.author?.username === profile?.username;
 
   const fetchPost = useCallback(async () => {
     try {
@@ -204,6 +226,95 @@ export default function PostPageClient({ id }: Props) {
     }
   };
 
+  // Edit/delete talk to backend endpoints that are not implemented yet. Expected contracts:
+  //   PATCH  /forum/posts/:id      body { title, content }   -> 200 updated post (author only)
+  //   DELETE /forum/posts/:id                                 -> 200 { ok: true }  (author only)
+  //   PATCH  /forum/comments/:id   body { content }          -> 200 updated comment (author only)
+  //   DELETE /forum/comments/:id                              -> 200 { ok: true }  (author only)
+  // Non-owners get 403; a missing row gets 404. Until they exist these calls 404 and the
+  // handlers surface the error toast.
+
+  const startEditPost = () => {
+    if (!post) return;
+    setEditTitle(post.title);
+    setEditContent(post.content);
+    setEditingPost(true);
+  };
+
+  const handleUpdatePost = async () => {
+    if (!post || savingPost) return;
+    setSavingPost(true);
+    try {
+      const res = await apiFetch(`/forum/posts/${post.id}`, {
+        method: 'PATCH',
+        body: JSON.stringify({ title: editTitle, content: editContent }),
+      });
+      if (!res.ok) throw new Error(`Failed to save post (${res.status})`);
+      setPost((p) => (p ? { ...p, title: editTitle, content: editContent } : p));
+      setEditingPost(false);
+      toast.success('Post updated.');
+    } catch (error) {
+      console.error('Error updating post:', error);
+      toast.error('Could not save your changes.');
+    } finally {
+      setSavingPost(false);
+    }
+  };
+
+  const handleDeletePost = async () => {
+    if (!post) return;
+    if (!window.confirm('Delete this post? This cannot be undone.')) return;
+    try {
+      const res = await apiFetch(`/forum/posts/${post.id}`, { method: 'DELETE' });
+      if (!res.ok) throw new Error(`Failed to delete post (${res.status})`);
+      toast.success('Post deleted.');
+      router.push('/forum');
+    } catch (error) {
+      console.error('Error deleting post:', error);
+      toast.error('Could not delete this post.');
+    }
+  };
+
+  const startEditComment = (comment: CommentRow) => {
+    setEditingCommentId(comment.id);
+    setEditCommentContent(comment.content);
+  };
+
+  const handleUpdateComment = async (commentId: string) => {
+    if (savingComment) return;
+    setSavingComment(true);
+    try {
+      const res = await apiFetch(`/forum/comments/${commentId}`, {
+        method: 'PATCH',
+        body: JSON.stringify({ content: editCommentContent }),
+      });
+      if (!res.ok) throw new Error(`Failed to save comment (${res.status})`);
+      setComments((prev) =>
+        prev.map((c) => (c.id === commentId ? { ...c, content: editCommentContent } : c))
+      );
+      setEditingCommentId(null);
+      toast.success('Comment updated.');
+    } catch (error) {
+      console.error('Error updating comment:', error);
+      toast.error('Could not save your changes.');
+    } finally {
+      setSavingComment(false);
+    }
+  };
+
+  const handleDeleteComment = async (commentId: string) => {
+    if (!window.confirm('Delete this comment? This cannot be undone.')) return;
+    try {
+      const res = await apiFetch(`/forum/comments/${commentId}`, { method: 'DELETE' });
+      if (!res.ok) throw new Error(`Failed to delete comment (${res.status})`);
+      setComments((prev) => prev.filter((c) => c.id !== commentId));
+      toast.success('Comment deleted.');
+    } catch (error) {
+      console.error('Error deleting comment:', error);
+      toast.error('Could not delete this comment.');
+    }
+  };
+
   if (notFound) {
     return (
       <div className="bg-background text-foreground">
@@ -244,25 +355,78 @@ export default function PostPageClient({ id }: Props) {
 
         <Card className="mb-8">
           <CardContent className="py-8 px-6 border-none">
-            <h1 className="text-3xl md:text-4xl font-semibold tracking-tight text-foreground mb-4">
-              {post.title}
-            </h1>
+            {editingPost ? (
+              <div className="mb-4 space-y-3">
+                <input
+                  type="text"
+                  value={editTitle}
+                  onChange={(e) => setEditTitle(e.target.value)}
+                  className="w-full p-3 rounded-md border border-border-strong bg-surface-100 text-lg font-semibold text-foreground focus:outline-none focus:border-brand-highlight"
+                  aria-label="Post title"
+                />
+                <ReactQuill
+                  value={editContent}
+                  onChange={setEditContent}
+                  theme="bubble"
+                  className="rounded-md border border-border-strong text-foreground-light leading-relaxed"
+                />
+                <div className="flex items-center gap-2">
+                  <Button
+                    type="primary"
+                    size="tiny"
+                    onClick={handleUpdatePost}
+                    disabled={savingPost || editTitle.trim() === ''}
+                  >
+                    {savingPost ? 'Saving…' : 'Save'}
+                  </Button>
+                  <Button type="default" size="tiny" onClick={() => setEditingPost(false)}>
+                    Cancel
+                  </Button>
+                </div>
+              </div>
+            ) : (
+              <>
+                <h1 className="text-3xl md:text-4xl font-semibold tracking-tight text-foreground mb-4">
+                  {post.title}
+                </h1>
 
-            <ReactQuill
-              value={post.content}
-              readOnly
-              theme="bubble"
-              className="text-foreground-light leading-relaxed mb-4"
-            />
+                <ReactQuill
+                  value={post.content}
+                  readOnly
+                  theme="bubble"
+                  className="text-foreground-light leading-relaxed mb-4"
+                />
+              </>
+            )}
 
             <div className="flex items-center justify-between flex-wrap gap-3 pt-4 border-t border-border-default">
-              <span className="text-sm text-foreground-lighter">
-                By{' '}
-                <span className="font-semibold text-foreground-light">
-                  {post.author?.username ?? 'Unknown'}
-                </span>{' '}
-                on {new Date(post.createdAt).toISOString().split('T')[0]}
-              </span>
+              <div className="flex items-center gap-3 flex-wrap">
+                <span className="text-sm text-foreground-lighter">
+                  By{' '}
+                  <span className="font-semibold text-foreground-light">
+                    {post.author?.username ?? 'Unknown'}
+                  </span>{' '}
+                  on {new Date(post.createdAt).toISOString().split('T')[0]}
+                </span>
+                {ownsPost && !editingPost && (
+                  <span className="flex items-center gap-1">
+                    <button
+                      onClick={startEditPost}
+                      className="inline-flex items-center gap-1 text-xs text-foreground-lighter hover:text-foreground transition-colors"
+                    >
+                      <Pencil1Icon width="12" height="12" />
+                      Edit
+                    </button>
+                    <button
+                      onClick={handleDeletePost}
+                      className="inline-flex items-center gap-1 text-xs text-foreground-lighter hover:text-destructive transition-colors"
+                    >
+                      <TrashIcon width="12" height="12" />
+                      Delete
+                    </button>
+                  </span>
+                )}
+              </div>
 
               <div className="flex items-center gap-2">
                 <button
@@ -305,10 +469,41 @@ export default function PostPageClient({ id }: Props) {
           ) : (
             comments.map((comment) => {
               const userVote = commentVotes[comment.id] ?? 0;
+              const ownsComment = isLoggedIn && comment.author?.username === profile?.username;
+              const isEditingThis = editingCommentId === comment.id;
               return (
                 <Card key={comment.id}>
                   <CardContent className="p-5 border-none">
-                    <p className="text-foreground-light whitespace-pre-wrap">{comment.content}</p>
+                    {isEditingThis ? (
+                      <div className="space-y-2">
+                        <textarea
+                          value={editCommentContent}
+                          onChange={(e) => setEditCommentContent(e.target.value)}
+                          rows={3}
+                          className="w-full p-2 rounded-md border border-border-strong bg-surface-100 text-sm text-foreground focus:outline-none focus:border-brand-highlight"
+                          aria-label="Edit comment"
+                        />
+                        <div className="flex items-center gap-2">
+                          <Button
+                            type="primary"
+                            size="tiny"
+                            onClick={() => handleUpdateComment(comment.id)}
+                            disabled={savingComment || editCommentContent.trim() === ''}
+                          >
+                            {savingComment ? 'Saving…' : 'Save'}
+                          </Button>
+                          <Button
+                            type="default"
+                            size="tiny"
+                            onClick={() => setEditingCommentId(null)}
+                          >
+                            Cancel
+                          </Button>
+                        </div>
+                      </div>
+                    ) : (
+                      <p className="text-foreground-light whitespace-pre-wrap">{comment.content}</p>
+                    )}
                     <div className="mt-3 flex items-center justify-between flex-wrap gap-2">
                       <p className="text-xs text-foreground-lighter">
                         By{' '}
@@ -316,6 +511,24 @@ export default function PostPageClient({ id }: Props) {
                           {comment.author?.username ?? 'Unknown'}
                         </span>{' '}
                         on {new Date(comment.createdAt).toISOString().split('T')[0]}
+                        {ownsComment && !isEditingThis && (
+                          <>
+                            {' · '}
+                            <button
+                              onClick={() => startEditComment(comment)}
+                              className="text-foreground-lighter hover:text-foreground transition-colors"
+                            >
+                              Edit
+                            </button>
+                            {' · '}
+                            <button
+                              onClick={() => handleDeleteComment(comment.id)}
+                              className="text-foreground-lighter hover:text-destructive transition-colors"
+                            >
+                              Delete
+                            </button>
+                          </>
+                        )}
                       </p>
                       <div className="flex items-center gap-1.5">
                         <button


### PR DESCRIPTION
## Description

Once you post or comment, there is no way to fix a typo or take it back. This adds author-only edit and delete on the post detail page and on each comment.

This is the **frontend half**. The backend endpoints do not exist yet, so the calls 404 until they land (the handlers show an error toast, nothing breaks). I built the UI against the contracts below so the backend can be dropped in without frontend changes. Owner gating in the UI is a username match only; the real authorship check must live in the backend.

## Backend contracts (to implement next)

All author-only. Non-owner -> 403, missing row -> 404, and each write must purge the forum cache like the other forum mutations.

| Method | Path | Body | Success |
| --- | --- | --- | --- |
| PATCH | `/forum/posts/:id` | `{ title, content }` | `200` updated post |
| DELETE | `/forum/posts/:id` | none | `200 { ok: true }` |
| PATCH | `/forum/comments/:id` | `{ content }` | `200` updated comment |
| DELETE | `/forum/comments/:id` | none | `200 { ok: true }` |

## Changes

- `[id]/PostPageClient.tsx`:
  - Post: an Edit control swaps the title and body for an input + Quill editor; Save calls `PATCH /forum/posts/:id` and updates local state. Delete confirms, calls `DELETE /forum/posts/:id`, then routes back to `/forum`.
  - Comment: Edit swaps the text for a textarea; Save calls `PATCH /forum/comments/:id`. Delete confirms, calls `DELETE /forum/comments/:id`, and removes it from the list.
  - Controls render only when the current user's username matches the author's, and never in an active edit form.

## Testing

- `bun run typecheck`, `bun run lint`, and `bun run format` pass.
- Manual UI: controls appear only on your own post/comment; edit forms toggle and cancel; delete asks to confirm. Backend calls currently 404, which surfaces the error toast as designed.

## Linked issues

Refs #

## Checklist

- [x] I read CONTRIBUTING.md and gave my own code a once-over (it runs and does what the PR says)
- [x] `tsc`, lint, and tests pass locally (CI checks these too)
- [ ] New backend feature code (`backend/src/`) has vitest tests
- [x] Code is formatted and matches the surrounding style (CI checks this)
- [x] Docs/comments updated if behavior or APIs changed
 